### PR TITLE
Sun

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Estimate outdoor illuminance based on time of day and current weather conditions
 
 See: https://community.home-assistant.io/t/outdoor-illuminance-estimated-from-weather-conditions-reported-by-weather-underground
 ### sun.py
-Add sunrise & sunset attributes updated at midnight.
+Add sunrise & sunset attributes updated at midnight. Add monitored_conditions config item to specify which attributes to maintain. If not specified then original set will be used. For elevation and azimuth, add scan_interval (minimum of one minute.) If next_rising or next_setting are not specified they will not be added as attributes. However, they will always be maintained anyway so that sun's state can be determined/maintained.
 ## python_scripts
 ### light_store.py
 Save and restore state of switches and lights (and groups of them.)

--- a/custom_components/sun.py
+++ b/custom_components/sun.py
@@ -7,9 +7,12 @@ https://home-assistant.io/components/sun/
 import asyncio
 import logging
 from datetime import timedelta
+import voluptuous as vol
 
-from homeassistant.const import CONF_ELEVATION
+from homeassistant.const import (CONF_ELEVATION, CONF_MONITORED_CONDITIONS,
+    CONF_SCAN_INTERVAL)
 from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
     async_track_point_in_utc_time, async_track_utc_time_change)
@@ -22,6 +25,8 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'sun'
 
 ENTITY_ID = 'sun.sun'
+
+MIN_SCAN_INTERVAL = timedelta(minutes=1)
 
 STATE_ABOVE_HORIZON = 'above_horizon'
 STATE_BELOW_HORIZON = 'below_horizon'
@@ -36,17 +41,30 @@ STATE_ATTR_NEXT_RISING = 'next_rising'
 STATE_ATTR_NEXT_SETTING = 'next_setting'
 STATE_ATTR_SUNRISE = 'sunrise'
 STATE_ATTR_SUNSET = 'sunset'
+DEFAULT_STATE_ATTRS = [STATE_ATTR_AZIMUTH, STATE_ATTR_ELEVATION,
+    STATE_ATTR_NEXT_DAWN, STATE_ATTR_NEXT_DUSK, STATE_ATTR_NEXT_MIDNIGHT,
+    STATE_ATTR_NEXT_NOON, STATE_ATTR_NEXT_RISING, STATE_ATTR_NEXT_SETTING]
+OPTIONAL_STATE_ATTRS = [STATE_ATTR_SUNRISE, STATE_ATTR_SUNSET]
+STATE_ATTRS = DEFAULT_STATE_ATTRS + OPTIONAL_STATE_ATTRS
 
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_MONITORED_CONDITIONS, default=DEFAULT_STATE_ATTRS):
+            vol.All(cv.ensure_list, [vol.In(STATE_ATTRS)]),
+        vol.Optional(CONF_SCAN_INTERVAL):
+            vol.All(cv.time_period, vol.Clamp(min=MIN_SCAN_INTERVAL))})},
+    extra=vol.ALLOW_EXTRA)
 
 @asyncio.coroutine
 def async_setup(hass, config):
     """Track the state of the sun."""
+    _LOGGER.debug('config: {}'.format(config))
     if config.get(CONF_ELEVATION) is not None:
         _LOGGER.warning(
             "Elevation is now configured in home assistant core. "
             "See https://home-assistant.io/docs/configuration/basic/")
 
-    sun = Sun(hass, get_astral_location(hass))
+    sun = Sun(hass, get_astral_location(hass), config[DOMAIN])
     sun.point_in_time_listener(dt_util.utcnow())
 
     return True
@@ -57,17 +75,33 @@ class Sun(Entity):
 
     entity_id = ENTITY_ID
 
-    def __init__(self, hass, location):
+    def __init__(self, hass, location, config):
         """Initialize the sun."""
+        self._monitored_condtions = config[CONF_MONITORED_CONDITIONS]
+        scan_interval = config.get(CONF_SCAN_INTERVAL)
         self.hass = hass
         self.location = location
-        self._state = self.next_rising = self.next_setting = None
-        self.sunrise = self.sunset = None
-        self.next_dawn = self.next_dusk = None
-        self.next_midnight = self.next_noon = None
-        self.solar_elevation = self.solar_azimuth = None
+        # Initialize values for attributes to be reported.
+        for a in self._monitored_condtions:
+            setattr(self, a, None)
+        # Make sure STATE_ATTR_NEXT_RISING & STATE_ATTR_NEXT_SETTING are
+        # defined since they are used to calculate state. Initialize them.
+        setattr(self, STATE_ATTR_NEXT_RISING, None)
+        setattr(self, STATE_ATTR_NEXT_SETTING, None)
+        self._state = None
+        self._update_position = (
+            STATE_ATTR_AZIMUTH in self._monitored_condtions or
+            STATE_ATTR_ELEVATION in self._monitored_condtions)
 
-        async_track_utc_time_change(hass, self.timer_update, second=30)
+        if self._update_position:
+            if scan_interval:
+                async_track_time_interval(hass, self.timer_update,
+                                          scan_interval)
+            else:
+                # If scan_interval not specified, use old method of updating
+                # once a minute on the half minute (i.e., now == xx:xx:30.)
+                async_track_utc_time_change(hass, self.timer_update,
+                                            second=30)
 
     @property
     def name(self):
@@ -77,7 +111,8 @@ class Sun(Entity):
     @property
     def state(self):
         """Return the state of the sun."""
-        if self.next_rising > self.next_setting:
+        if (getattr(self, STATE_ATTR_NEXT_RISING) >
+                getattr(self, STATE_ATTR_NEXT_SETTING)):
             return STATE_ABOVE_HORIZON
 
         return STATE_BELOW_HORIZON
@@ -85,59 +120,81 @@ class Sun(Entity):
     @property
     def state_attributes(self):
         """Return the state attributes of the sun."""
-        return {
-            STATE_ATTR_NEXT_DAWN: self.next_dawn.isoformat(),
-            STATE_ATTR_NEXT_DUSK: self.next_dusk.isoformat(),
-            STATE_ATTR_NEXT_MIDNIGHT: self.next_midnight.isoformat(),
-            STATE_ATTR_NEXT_NOON: self.next_noon.isoformat(),
-            STATE_ATTR_NEXT_RISING: self.next_rising.isoformat(),
-            STATE_ATTR_NEXT_SETTING: self.next_setting.isoformat(),
-            STATE_ATTR_SUNRISE: self.sunrise.isoformat(),
-            STATE_ATTR_SUNSET: self.sunset.isoformat(),
-            STATE_ATTR_ELEVATION: round(self.solar_elevation, 2),
-            STATE_ATTR_AZIMUTH: round(self.solar_azimuth, 2)
-        }
+        attrs = {}
+        for a in [STATE_ATTR_NEXT_DAWN,
+                  STATE_ATTR_NEXT_DUSK,
+                  STATE_ATTR_NEXT_MIDNIGHT,
+                  STATE_ATTR_NEXT_NOON,
+                  STATE_ATTR_NEXT_RISING,
+                  STATE_ATTR_NEXT_SETTING,
+                  STATE_ATTR_SUNRISE,
+                  STATE_ATTR_SUNSET]:
+            if a in self._monitored_condtions:
+                attrs[a] = getattr(self, a).isoformat()
+        for a in [STATE_ATTR_ELEVATION,
+                  STATE_ATTR_AZIMUTH]:
+            if a in self._monitored_condtions:
+                attrs[a] = round(getattr(self, a), 2)
+        return attrs
 
     @property
     def next_change(self):
         """Datetime when the next change to the state is."""
-        # next_midnight is next solar midnight. So get actual midnight,
-        # but subtract a second because point_in_time_listener() will add one.
-        midnight = dt_util.as_utc(dt_util.start_of_local_day(
-            dt_util.now()+timedelta(1))-timedelta(seconds=1))
-        return min(self.next_dawn, self.next_dusk, self.next_midnight,
-                   self.next_noon, self.next_rising, self.next_setting, midnight)
+        # Always need to update next rising and next setting so state can be
+        # determined.
+        next_events = [getattr(self, STATE_ATTR_NEXT_RISING),
+                       getattr(self, STATE_ATTR_NEXT_SETTING)]
+        # Only need to update remaining properties if they will be reported
+        # in attributes.
+        for a in [STATE_ATTR_NEXT_DAWN,
+                  STATE_ATTR_NEXT_DUSK,
+                  STATE_ATTR_NEXT_MIDNIGHT,
+                  STATE_ATTR_NEXT_NOON]:
+            if a in self._monitored_condtions:
+                next_events.append(getattr(self, a))
+        # For sunrise and sunset, update at next "real" midnight (as opposed
+        # to next_midnight, which is solar midnight.) But subtract one
+        # second because point_in_time_listener() will add one.
+        if (STATE_ATTR_SUNRISE in self._monitored_condtions or
+                STATE_ATTR_SUNSET in self._monitored_condtions):
+            next_events.append(dt_util.as_utc(dt_util.start_of_local_day(
+            dt_util.now()+timedelta(days=1))-timedelta(seconds=1)))
+        return min(next_events)
 
     @callback
-    def update_as_of(self, utc_point_in_time):
+    def update_as_of(self, utc_time):
         """Update the attributes containing solar events."""
-        self.next_dawn = get_astral_event_next(
-            self.hass, 'dawn', utc_point_in_time)
-        self.next_dusk = get_astral_event_next(
-            self.hass, 'dusk', utc_point_in_time)
-        self.next_midnight = get_astral_event_next(
-            self.hass, 'solar_midnight', utc_point_in_time)
-        self.next_noon = get_astral_event_next(
-            self.hass, 'solar_noon', utc_point_in_time)
-        self.next_rising = get_astral_event_next(
-            self.hass, 'sunrise', utc_point_in_time)
-        self.next_setting = get_astral_event_next(
-            self.hass, 'sunset', utc_point_in_time)
-        self.sunrise = get_astral_event_date(
-            self.hass, 'sunrise', utc_point_in_time)
-        self.sunset = get_astral_event_date(
-            self.hass, 'sunset', utc_point_in_time)
+        # Always need to update next_rising and next_setting so state can be
+        # determined.
+        for a, e in [(STATE_ATTR_NEXT_RISING, 'sunrise'),
+                     (STATE_ATTR_NEXT_SETTING, 'sunset')]:
+            setattr(self, a, get_astral_event_next(self.hass, e, utc_time))
+        # Only need to update remaining properties if they will be reported
+        # in attributes.
+        for a, e in [(STATE_ATTR_NEXT_DAWN, 'dawn'),
+                     (STATE_ATTR_NEXT_DUSK, 'dusk'),
+                     (STATE_ATTR_NEXT_MIDNIGHT, 'solar_midnight'),
+                     (STATE_ATTR_NEXT_NOON, 'solar_noon')]:
+            if a in self._monitored_condtions:
+                setattr(self, a, get_astral_event_next(self.hass, e, utc_time))
+        for a, e in [(STATE_ATTR_SUNRISE, 'sunrise'),
+                     (STATE_ATTR_SUNSET, 'sunset')]:
+            if a in self._monitored_condtions:
+                setattr(self, a, get_astral_event_date(self.hass, e, utc_time))
 
     @callback
-    def update_sun_position(self, utc_point_in_time):
+    def update_sun_position(self, utc_time):
         """Calculate the position of the sun."""
-        self.solar_azimuth = self.location.solar_azimuth(utc_point_in_time)
-        self.solar_elevation = self.location.solar_elevation(utc_point_in_time)
+        setattr(self, STATE_ATTR_AZIMUTH,
+            self.location.solar_azimuth(utc_time))
+        setattr(self, STATE_ATTR_ELEVATION,
+            self.location.solar_elevation(utc_time))
 
     @callback
     def point_in_time_listener(self, now):
         """Run when the state of the sun has changed."""
-        self.update_sun_position(now)
+        if self._update_position:
+            self.update_sun_position(now)
         self.update_as_of(now)
         self.async_schedule_update_ha_state()
 


### PR DESCRIPTION
Add monitored_conditions config item to specify which attributes to maintain. If not specified then original set will be used. For elevation and azimuth, add scan_interval (minimum of one minute.) If next_rising or next_setting are not specified they will not be added as attributes. However, they will always be maintained anyway so that sun's state can be determined/maintained.