### PR TITLE
Filter errors in life360

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -8,8 +8,8 @@
     "changelog": "https://github.com/pnbruckner/homeassistant-config/releases"
   },
   "device_tracker.life360": {
-    "updated_at": "2018-09-10",
-    "version": "1.1.0",
+    "updated_at": "2018-09-12",
+    "version": "1.2.0",
     "local_location": "/custom_components/device_tracker/life360.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/life360.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",


### PR DESCRIPTION
If multiple errors occur consecutively for a given query or member, only log the first two and then no more until the errors stop. Closes #12.