### PR TITLE
Add thread locking to composite tracker

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -1,7 +1,7 @@
 {
   "device_tracker.composite": {
-    "updated_at": "2018-09-07",
-    "version": "1.0.0",
+    "updated_at": "2018-09-20",
+    "version": "1.0.1",
     "local_location": "/custom_components/device_tracker/composite.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/composite.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/device_tracker/composite.py
+++ b/custom_components/device_tracker/composite.py
@@ -6,6 +6,7 @@ https://github.com/pnbruckner/homeassistant-config#device_trackercompositepy
 """
 
 import logging
+import threading
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
@@ -17,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_state_change
 from homeassistant.util import dt as dt_util
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,6 +42,7 @@ class CompositeScanner:
         entities = config[CONF_ENTITY_ID]
         self._entities = dict.fromkeys(entities, False)
         self._dev_id = config[CONF_NAME]
+        self._lock = threading.Lock()
         self._prev_seen = None
 
         self._remove = track_state_change(
@@ -62,36 +64,39 @@ class CompositeScanner:
             self._entities[entity_id] = True
 
     def _update_info(self, entity_id, old_state, new_state):
-        # Get time device was last seen, which is the entity's last_seen
-        # attribute, or if that doesn't exist, then last_updated from the new
-        # state object. Make sure last_seen is timezone aware in UTC. Note
-        # that dt_util.as_utc assumes naive datetime is in local timezone.
-        last_seen = dt_util.as_utc(
-            new_state.attributes.get(ATTR_LAST_SEEN, new_state.last_updated))
+        with self._lock:
+            # Get time device was last seen, which is the entity's last_seen
+            # attribute, or if that doesn't exist, then last_updated from the
+            # new state object. Make sure last_seen is timezone aware in UTC.
+            # Note that dt_util.as_utc assumes naive datetime is in local
+            # timezone.
+            last_seen = dt_util.as_utc(
+                new_state.attributes.get(ATTR_LAST_SEEN,
+                                         new_state.last_updated))
 
-        # Is this newer info than last update?
-        if self._prev_seen and self._prev_seen >= last_seen:
-            _LOGGER.debug("Skipping: prv({}) >= new({})".format(
-                self._prev_seen, last_seen))
-            return
+            # Is this newer info than last update?
+            if self._prev_seen and self._prev_seen >= last_seen:
+                _LOGGER.debug("Skipping: prv({}) >= new({})".format(
+                    self._prev_seen, last_seen))
+                return
 
-        # GPS coordinates and accuracy are required.
-        # Battery level is optional.
-        try:
-            gps = (new_state.attributes[ATTR_LATITUDE],
-                   new_state.attributes[ATTR_LONGITUDE])
-        except KeyError:
-            self._bad_entity(entity_id, "missing gps attributes")
-            return
-        try:
-            gps_accuracy = new_state.attributes[ATTR_GPS_ACCURACY]
-        except KeyError:
-            self._bad_entity(entity_id, "missing gps_accuracy attribute")
-            return
-        battery = new_state.attributes.get(ATTR_BATTERY)
+            # GPS coordinates and accuracy are required.
+            # Battery level is optional.
+            try:
+                gps = (new_state.attributes[ATTR_LATITUDE],
+                       new_state.attributes[ATTR_LONGITUDE])
+            except KeyError:
+                self._bad_entity(entity_id, "missing gps attributes")
+                return
+            try:
+                gps_accuracy = new_state.attributes[ATTR_GPS_ACCURACY]
+            except KeyError:
+                self._bad_entity(entity_id, "missing gps_accuracy attribute")
+                return
+            battery = new_state.attributes.get(ATTR_BATTERY)
 
-        attrs = {ATTR_LAST_SEEN: last_seen.replace(microsecond=0)}
-        self._see(dev_id=self._dev_id, gps=gps, gps_accuracy=gps_accuracy,
-            battery=battery, attributes=attrs)
+            attrs = {ATTR_LAST_SEEN: last_seen.replace(microsecond=0)}
+            self._see(dev_id=self._dev_id, gps=gps, gps_accuracy=gps_accuracy,
+                battery=battery, attributes=attrs)
 
-        self._prev_seen = last_seen
+            self._prev_seen = last_seen

--- a/docs/composite.md
+++ b/docs/composite.md
@@ -33,3 +33,4 @@ The watched devices, and the composite device, should all have `track` set to `t
 Date | Version | Notes
 -|:-:|-
 20180907 | [1.0.0](https://github.com/pnbruckner/homeassistant-config/blob/d767bcce0fdff0c9298dc7a010d27af88817eac2/custom_components/device_tracker/composite.py) | Initial support for Custom Updater.
+20180920 | [1.0.1](https://github.com/pnbruckner/homeassistant-config/blob/959a691afb5e2b98e946591b9ff58291f104a74a/custom_components/device_tracker/composite.py) | Add thread locking to protect against multiple entities updating too close together.


### PR DESCRIPTION
Protect against _update_info method being run multiple times concurrently if multiple entities update too close together. Bump version to 1.0.1. Fixes #27.