### PR TITLE
Composite tracker: Add entity_id & last_entity_id attributes and fix binary_sensor bug

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -1,7 +1,7 @@
 {
   "device_tracker.composite": {
     "updated_at": "2018-09-26",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "local_location": "/custom_components/device_tracker/composite.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/composite.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/device_tracker/composite.py
+++ b/custom_components/device_tracker/composite.py
@@ -27,7 +27,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_state_change
 from homeassistant.util import dt as dt_util
 
-__version__ = '1.3.0.b3'
+__version__ = '1.3.0'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/device_tracker/composite.py
+++ b/custom_components/device_tracker/composite.py
@@ -20,14 +20,14 @@ try:
 except ImportError:
     from homeassistant.components.zone import active_zone
 from homeassistant.const import (
-    ATTR_GPS_ACCURACY, ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_STATE,
-    CONF_ENTITY_ID, CONF_NAME, EVENT_HOMEASSISTANT_START, STATE_HOME,
-    STATE_NOT_HOME, STATE_ON)
+    ATTR_GPS_ACCURACY, ATTR_ENTITY_ID, ATTR_LATITUDE, ATTR_LONGITUDE,
+    ATTR_STATE, CONF_ENTITY_ID, CONF_NAME, EVENT_HOMEASSISTANT_START,
+    STATE_HOME, STATE_NOT_HOME, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_state_change
 from homeassistant.util import dt as dt_util
 
-__version__ = '1.2.0'
+__version__ = '1.3.0.b1'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -219,7 +219,11 @@ class CompositeScanner:
                     remove_now=True)
                 return
 
-            attrs = {ATTR_LAST_SEEN: last_seen.replace(microsecond=0)}
+            attrs = {
+                ATTR_LAST_SEEN: last_seen.replace(microsecond=0),
+                ATTR_ENTITY_ID: tuple(
+                    entity_id for entity_id, entity in self._entities.items()
+                    if entity[ATTR_SOURCE_TYPE] is not None)}
             self._see(dev_id=self._dev_id, location_name=location_name,
                 gps=gps, gps_accuracy=gps_accuracy, battery=battery,
                 attributes=attrs, source_type=source_type)

--- a/custom_components/device_tracker/composite.py
+++ b/custom_components/device_tracker/composite.py
@@ -27,11 +27,12 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_state_change
 from homeassistant.util import dt as dt_util
 
-__version__ = '1.3.0.b1'
+__version__ = '1.3.0.b2'
 
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_LAST_SEEN = 'last_seen'
+ATTR_LAST_ENTITY_ID = 'last_entity_id'
 
 WARNED = 'warned'
 SOURCE_TYPE = ATTR_SOURCE_TYPE
@@ -220,10 +221,11 @@ class CompositeScanner:
                 return
 
             attrs = {
-                ATTR_LAST_SEEN: last_seen.replace(microsecond=0),
                 ATTR_ENTITY_ID: tuple(
                     entity_id for entity_id, entity in self._entities.items()
-                    if entity[ATTR_SOURCE_TYPE] is not None)}
+                    if entity[ATTR_SOURCE_TYPE] is not None),
+                ATTR_LAST_ENTITY_ID: entity_id,
+                ATTR_LAST_SEEN: last_seen.replace(microsecond=0)}
             self._see(dev_id=self._dev_id, location_name=location_name,
                 gps=gps, gps_accuracy=gps_accuracy, battery=battery,
                 attributes=attrs, source_type=source_type)

--- a/docs/composite.md
+++ b/docs/composite.md
@@ -43,6 +43,7 @@ Attribute | Description
 battery | Battery level (in percent, if available.)
 entity_id | IDs of entities that have contributed to the state of the composite device.
 gps_accuracy | GPS accuracy radius (in meters, if available.)
+last_entity_id | ID of the last entity to update the composite device.
 last_seen | Date and time when current location information was last updated.
 latitude | Latitude of current location (if available.)
 longitude | Longitude of current location (if available.)

--- a/docs/composite.md
+++ b/docs/composite.md
@@ -37,6 +37,16 @@ The watched devices, and the composite device, should all have `track` set to `t
 It's recommended, as well, to set `hide_if_away` to `true` for the watched devices (but leave it set to `false` for the composite device.) This way the map will only show the composite device (when it is out of the home zone.)
 
 Lastly, it is also recommended to _not_ use the native merge feature of the device tracker component (i.e., do not add the MAC address from network-based trackers to a GPS-based tracker. See more details in the [Device Tracker doc page](https://www.home-assistant.io/components/device_tracker/#using-gps-device-trackers-with-local-network-device-trackers).)
+## Attributes
+Attribute | Description
+-|-
+battery | Battery level (in percent, if available.)
+entity_id | IDs of entities that have contributed to the state of the composite device.
+gps_accuracy | GPS accuracy radius (in meters, if available.)
+last_seen | Date and time when current location information was last updated.
+latitude | Latitude of current location (if available.)
+longitude | Longitude of current location (if available.)
+source_type | Source of current location information: `binary_sensor`, `bluetooth`, `bluetooth_le`, `gps` or `router`.
 ## Release Notes
 Date | Version | Notes
 -|:-:|-
@@ -44,3 +54,4 @@ Date | Version | Notes
 20180920 | [1.0.1](https://github.com/pnbruckner/homeassistant-config/blob/d5dd426bbf28a8f7bd5241bfe0603e67bc29f951/custom_components/device_tracker/composite.py) | Add thread locking to protect against multiple entities updating too close together.
 20180925 | [1.1.0](https://github.com/pnbruckner/homeassistant-config/blob/d57cc5bdae4eeee98d0eebb6cba493243e20c0cd/custom_components/device_tracker/composite.py) | Add support for network-based (aka router) device trackers.
 20180926 | [1.2.0](https://github.com/pnbruckner/homeassistant-config/blob/67ca1774af55c9d1b84672160ad07a7a34fbbf4c/custom_components/device_tracker/composite.py) | Add support for bluetooth device trackers and binary sensors.
+20180926 | [1.3.0]() | Add entity_id attribute.

--- a/docs/composite.md
+++ b/docs/composite.md
@@ -55,4 +55,4 @@ Date | Version | Notes
 20180920 | [1.0.1](https://github.com/pnbruckner/homeassistant-config/blob/d5dd426bbf28a8f7bd5241bfe0603e67bc29f951/custom_components/device_tracker/composite.py) | Add thread locking to protect against multiple entities updating too close together.
 20180925 | [1.1.0](https://github.com/pnbruckner/homeassistant-config/blob/d57cc5bdae4eeee98d0eebb6cba493243e20c0cd/custom_components/device_tracker/composite.py) | Add support for network-based (aka router) device trackers.
 20180926 | [1.2.0](https://github.com/pnbruckner/homeassistant-config/blob/67ca1774af55c9d1b84672160ad07a7a34fbbf4c/custom_components/device_tracker/composite.py) | Add support for bluetooth device trackers and binary sensors.
-20180926 | [1.3.0]() | Add entity_id attribute.
+20180926 | [1.3.0]() | Add entity_id and last_entity_id attributes. Fix bug in 1.2.0 that affected state of binary_sensors in state machine.


### PR DESCRIPTION
Add an entity_id attribute that is dynamically maintained with the list of "input" entities that have contributed to the current state of the composite device. Suggested in [this community forum post](https://community.home-assistant.io/t/composite-device-tracker-platform/67345/39). Closes #35. Fixes #37.