### PR TITLE
Life360: Update when initialization complete

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -8,8 +8,8 @@
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/composite.md#release-notes"
   },
   "device_tracker.life360": {
-    "updated_at": "2018-10-02",
-    "version": "1.5.1",
+    "updated_at": "2018-10-16",
+    "version": "1.6.0",
     "local_location": "/custom_components/device_tracker/life360.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/life360.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -23,7 +23,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_time_interval
 from homeassistant import util
 
-__version__ = '1.5.1'
+__version__ = '1.6.0b1'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -169,6 +169,7 @@ class Life360Scanner:
         self._dev_data = {}
         self._started = util.dt.utcnow()
 
+        self._update_life360()
         track_time_interval(self._hass, self._update_life360, interval)
 
     def _ok(self, key):

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -23,7 +23,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_time_interval
 from homeassistant import util
 
-__version__ = '1.6.0b1'
+__version__ = '1.6.0'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -124,6 +124,7 @@ Date | Version | Notes
 20180918 | [1.4.0](https://github.com/pnbruckner/homeassistant-config/blob/c0431151be81d402eaa25c87bfd069371c3bcd10/custom_components/device_tracker/life360.py) | Handle members that don't share their location in one or more circles.
 20180928 | [1.5.0](https://github.com/pnbruckner/homeassistant-config/blob/eb3dc1915c9289e741ba9db0471a271b0edd4677/custom_components/device_tracker/life360.py) | Add raw_speed and speed attributes and `driving_speed` config option. Derive `driving` attribute from speed if possible.
 20181002 | [1.5.1](https://github.com/pnbruckner/homeassistant-config/blob/6cf17f0a5e02ef556862247ee632d61ce58c7b09/custom_components/device_tracker/life360.py) | Limit speed attribute to non-negative values.
+20181016 | [1.6.0]() | Update as soon as initialization is complete.
 
 [Life360 Communications Module Release Notes](life360_lib.md#release-notes)
 


### PR DESCRIPTION
Call _update_life360 as soon as initialization is complete, right before setting up periodic calls. Bump version to 1.6.0b1. Resolves #46.