### PR TITLE
Composite tracker: Slugify config name

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -1,7 +1,7 @@
 {
   "device_tracker.composite": {
-    "updated_at": "2018-09-26",
-    "version": "1.3.0",
+    "updated_at": "2018-10-16",
+    "version": "1.4.0",
     "local_location": "/custom_components/device_tracker/composite.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/composite.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/device_tracker/composite.py
+++ b/custom_components/device_tracker/composite.py
@@ -25,9 +25,9 @@ from homeassistant.const import (
     STATE_HOME, STATE_NOT_HOME, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_state_change
-from homeassistant.util import dt as dt_util
+from homeassistant import util
 
-__version__ = '1.3.0'
+__version__ = '1.4.0b1'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -67,7 +67,7 @@ class CompositeScanner:
                 WARNED: False,
                 SOURCE_TYPE: None,
                 STATE: None}
-        self._dev_id = config[CONF_NAME]
+        self._dev_id = util.slugify(config[CONF_NAME])
         self._lock = threading.Lock()
         self._prev_seen = None
 
@@ -114,14 +114,14 @@ class CompositeScanner:
             # Get time device was last seen, which is the entity's last_seen
             # attribute, or if that doesn't exist, then last_updated from the
             # new state object. Make sure last_seen is timezone aware in UTC.
-            # Note that dt_util.as_utc assumes naive datetime is in local
+            # Note that util.dt.as_utc assumes naive datetime is in local
             # timezone.
             last_seen = new_state.attributes.get(ATTR_LAST_SEEN)
             if isinstance(last_seen, datetime):
-                last_seen = dt_util.as_utc(last_seen)
+                last_seen = util.dt.as_utc(last_seen)
             else:
                 try:
-                    last_seen = dt_util.utc_from_timestamp(float(last_seen))
+                    last_seen = util.dt.utc_from_timestamp(float(last_seen))
                 except (TypeError, ValueError):
                     last_seen = new_state.last_updated
 

--- a/custom_components/device_tracker/composite.py
+++ b/custom_components/device_tracker/composite.py
@@ -27,7 +27,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_state_change
 from homeassistant import util
 
-__version__ = '1.4.0b1'
+__version__ = '1.4.0'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/docs/composite.md
+++ b/docs/composite.md
@@ -56,3 +56,4 @@ Date | Version | Notes
 20180925 | [1.1.0](https://github.com/pnbruckner/homeassistant-config/blob/d57cc5bdae4eeee98d0eebb6cba493243e20c0cd/custom_components/device_tracker/composite.py) | Add support for network-based (aka router) device trackers.
 20180926 | [1.2.0](https://github.com/pnbruckner/homeassistant-config/blob/67ca1774af55c9d1b84672160ad07a7a34fbbf4c/custom_components/device_tracker/composite.py) | Add support for bluetooth device trackers and binary sensors.
 20180926 | [1.3.0](https://github.com/pnbruckner/homeassistant-config/blob/ed9bab69ea9cdd2bb2a892cf3a1b23f930119f0b/custom_components/device_tracker/composite.py) | Add entity_id and last_entity_id attributes. Fix bug in 1.2.0 that affected state of binary_sensors in state machine.
+20181016 | [1.4.0]() | Make sure name is valid object ID.


### PR DESCRIPTION
Use util.slugify to make sure config name will be valid device_tracker object ID. Bump version to 1.4.0b1. Resolves #48.