### PR TITLE
Composite tracker: Initialize and update immediately

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -1,7 +1,7 @@
 {
   "device_tracker.composite": {
-    "updated_at": "2018-10-16",
-    "version": "1.4.0",
+    "updated_at": "2018-10-19",
+    "version": "1.5.0",
     "local_location": "/custom_components/device_tracker/composite.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/composite.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/device_tracker/composite.py
+++ b/custom_components/device_tracker/composite.py
@@ -27,7 +27,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_state_change
 from homeassistant import util
 
-__version__ = '1.4.0'
+__version__ = '1.5.0b1'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,9 +51,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 def setup_scanner(hass, config, see, discovery_info=None):
-    def run_setup(event):
-        CompositeScanner(hass, config, see)
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)
+    CompositeScanner(hass, config, see)
     return True
 
 class CompositeScanner:
@@ -73,6 +71,9 @@ class CompositeScanner:
 
         self._remove = track_state_change(
             hass, entities, self._update_info)
+
+        for entity_id in entities:
+            self._update_info(entity_id, None, hass.states.get(entity_id))
 
     def _bad_entity(self, entity_id, message, remove_now=False):
         msg = '{} {}'.format(entity_id, message)

--- a/custom_components/device_tracker/composite.py
+++ b/custom_components/device_tracker/composite.py
@@ -27,7 +27,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_state_change
 from homeassistant import util
 
-__version__ = '1.5.0b1'
+__version__ = '1.5.0'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/docs/composite.md
+++ b/docs/composite.md
@@ -57,3 +57,4 @@ Date | Version | Notes
 20180926 | [1.2.0](https://github.com/pnbruckner/homeassistant-config/blob/67ca1774af55c9d1b84672160ad07a7a34fbbf4c/custom_components/device_tracker/composite.py) | Add support for bluetooth device trackers and binary sensors.
 20180926 | [1.3.0](https://github.com/pnbruckner/homeassistant-config/blob/ed9bab69ea9cdd2bb2a892cf3a1b23f930119f0b/custom_components/device_tracker/composite.py) | Add entity_id and last_entity_id attributes. Fix bug in 1.2.0 that affected state of binary_sensors in state machine.
 20181016 | [1.4.0](https://github.com/pnbruckner/homeassistant-config/blob/42faa22bdc3cc7cc63df3744a81bc235507996b6/custom_components/device_tracker/composite.py) | Make sure name is valid object ID.
+20181019 | [1.5.0]() | Remove initialization delay and update immediately according to current state of entities.


### PR DESCRIPTION
Remove initialization delay and then immediately update by using current states of configured entities, if any. Bump version to 1.5.0.