### PR TITLE
Life360: Create HA zones from Life360 Places

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -8,16 +8,16 @@
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/composite.md#release-notes"
   },
   "device_tracker.life360": {
-    "updated_at": "2018-10-25",
-    "version": "1.6.1",
+    "updated_at": "2018-11-02",
+    "version": "2.0.0",
     "local_location": "/custom_components/device_tracker/life360.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/life360.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/life360.md#release-notes"
   },
   "life360": {
-    "updated_at": "2018-09-07",
-    "version": "1.0.0",
+    "updated_at": "2018-11-02",
+    "version": "1.1.0",
     "local_location": "/custom_components/life360.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/life360.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -5,25 +5,33 @@ For more details about this platform, please refer to
 https://github.com/pnbruckner/homeassistant-config#life360py--device_trackerlife360py
 """
 
-import sys
-import datetime as dt
-from requests import HTTPError, ConnectionError, Timeout
-from json.decoder import JSONDecodeError
+from collections import namedtuple
+from datetime import timedelta
 import logging
-import voluptuous as vol
-try:
-    from homeassistant.components.zone.zone import active_zone
-except ImportError:
-    from homeassistant.components.zone import active_zone
-from homeassistant.components.device_tracker import (ENTITY_ID_FORMAT,
-    PLATFORM_SCHEMA, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD, CONF_FILENAME,
-    CONF_PREFIX, LENGTH_KILOMETERS, LENGTH_MILES, STATE_UNKNOWN)
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import track_time_interval
-from homeassistant import util
+import sys
 
-__version__ = '1.6.1'
+from json.decoder import JSONDecodeError
+from requests import HTTPError, ConnectionError, Timeout
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import (
+    CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL,
+    ENTITY_ID_FORMAT as DT_ENTITY_ID_FORMAT, PLATFORM_SCHEMA)
+from homeassistant.components.zone import (
+    DEFAULT_PASSIVE, ENTITY_ID_FORMAT as ZN_ENTITY_ID_FORMAT, HOME_ZONE, Zone)
+from homeassistant.components.zone.zone import active_zone
+from homeassistant.const import (
+    CONF_FILENAME, CONF_PASSWORD, CONF_PREFIX, CONF_USERNAME, LENGTH_FEET,
+    LENGTH_KILOMETERS, LENGTH_METERS, LENGTH_MILES, STATE_HOME, STATE_UNKNOWN)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import generate_entity_id
+from homeassistant.helpers.event import track_time_interval
+from homeassistant.util import slugify
+from homeassistant.util.distance import convert
+import homeassistant.util.dt as dt_util
+
+
+__version__ = '2.0.0b1'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,6 +39,8 @@ DEPENDENCIES = ['zone']
 
 DEFAULT_FILENAME = 'life360.conf'
 SPEED_FACTOR_MPH = 2.25
+DEFAULT_PLACE_INTERVAL = timedelta(minutes=15)
+ICON_LIFE360_PLACE = 'mdi:map-marker'
 
 _AUTHORIZATION_TOKEN = 'cFJFcXVnYWJSZXRyZTRFc3RldGhlcnVmcmVQdW1hbUV4dWNyRU'\
                        'h1YzptM2ZydXBSZXRSZXN3ZXJFQ2hBUHJFOTZxYWtFZHI0Vg=='
@@ -71,12 +81,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DRIVING_SPEED): vol.Coerce(float),
 })
 
+_API_EXCS = (HTTPError, ConnectionError, Timeout, JSONDecodeError)
+
+
 def exc_msg(exc):
     return '{}: {}'.format(exc.__class__.__name__, str(exc))
 
 def utc_from_ts(val):
     try:
-        return util.dt.utc_from_timestamp(float(val))
+        return dt_util.utc_from_timestamp(float(val))
     except (TypeError, ValueError):
         return None
 
@@ -130,7 +143,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
     prefix = config.get(CONF_PREFIX)
     members = config.get(CONF_MEMBERS)
     driving_speed = config.get(CONF_DRIVING_SPEED)
-    _LOGGER.debug('members = {}'.format(members))
+    _LOGGER.debug('Configured members = {}'.format(members))
 
     if members:
         _members = []
@@ -138,7 +151,8 @@ def setup_scanner(hass, config, see, discovery_info=None):
             try:
                 name = m_name(*member.split(','))
             except (TypeError, ValueError):
-                _LOGGER.error('Ignoring invalid member name: "{}"'.format(member))
+                _LOGGER.error(
+                    'Ignoring invalid member name: "{}"'.format(member))
                 continue
             _members.append(name)
         members = _members
@@ -146,6 +160,63 @@ def setup_scanner(hass, config, see, discovery_info=None):
         if not members:
             _LOGGER.error('No listed member names were valid')
             return False
+
+    Place = namedtuple('Place', ['name', 'latitude', 'longitude', 'radius'])
+
+    def get_places():
+        errs = 0
+        while True:
+            places = set()
+            try:
+                for circle in api.get_circles():
+                    for place in api.get_circle_places(circle['id']):
+                        name = place['name']
+                        if name.lower() == HOME_ZONE:
+                            continue
+                        places.add(Place(name,
+                                         float(place['latitude']),
+                                         float(place['longitude']),
+                                         float(place['radius'])))
+            except _API_EXCS + (KeyError, TypeError, ValueError) as exc:
+                errs += 1
+                if errs >= 3:
+                    _LOGGER.error('get_places: {}'.format(exc_msg(exc)))
+                    return None
+            else:
+                return places
+
+    def zone_from_place(place):
+        zone = Zone(hass, *place, ICON_LIFE360_PLACE, DEFAULT_PASSIVE)
+        zone.entity_id = generate_entity_id(ZN_ENTITY_ID_FORMAT, place.name,
+                                            None, hass)
+        zone.schedule_update_ha_state()
+        return zone
+
+    def log_places(msg, places):
+        _LOGGER.debug('{} zones for Places: {}'.format(
+            msg,
+            '; '.join(['{}: {}, {}, {}'.format(*place) for place
+                       in sorted(places, key=lambda x: x.name.lower())])))
+
+    def zones_from_places(now=None):
+        places = get_places()
+        if places is None:
+            return
+        remove_places = set(zones.keys()) - places
+        if remove_places:
+            log_places('Removing', remove_places)
+            for remove_place in remove_places:
+                hass.add_job(zones.pop(remove_place).async_remove())
+        add_places = places - set(zones.keys())
+        if add_places:
+            log_places('Adding', add_places)
+            for add_place in add_places:
+                zone = zone_from_place(add_place)
+                zones[add_place] = zone
+
+    zones = {}
+    zones_from_places()
+    track_time_interval(hass, zones_from_places, DEFAULT_PLACE_INTERVAL)
 
     Life360Scanner(hass, see, interval, show_as_state, max_gps_accuracy,
                    max_update_wait, prefix, members, driving_speed, api)
@@ -167,7 +238,7 @@ class Life360Scanner:
         self._errs = {}
         self._max_errs = 2
         self._dev_data = {}
-        self._started = util.dt.utcnow()
+        self._started = dt_util.utcnow()
 
         self._update_life360()
         track_time_interval(self._hass, self._update_life360, interval)
@@ -191,7 +262,7 @@ class Life360Scanner:
     def _update_member(self, m, name):
         name = name.replace(',', '_').replace('-', '_')
 
-        dev_id = util.slugify(self._prefix + name)
+        dev_id = slugify(self._prefix + name)
         prev_seen, reported = self._dev_data.get(dev_id, (None, False))
 
         loc = m.get('location')
@@ -202,16 +273,16 @@ class Life360Scanner:
 
         if self._max_update_wait:
             update = last_seen or prev_seen or self._started
-            overdue = util.dt.utcnow() - update > self._max_update_wait
+            overdue = dt_util.utcnow() - update > self._max_update_wait
             if overdue and not reported:
                 self._hass.bus.fire(
                     'life360_update_overdue',
-                    {'entity_id': ENTITY_ID_FORMAT.format(dev_id)})
+                    {'entity_id': DT_ENTITY_ID_FORMAT.format(dev_id)})
                 reported = True
             elif not overdue and reported:
                 self._hass.bus.fire(
                     'life360_update_restored', {
-                        'entity_id': ENTITY_ID_FORMAT.format(dev_id),
+                        'entity_id': DT_ENTITY_ID_FORMAT.format(dev_id),
                         'wait':
                             str(last_seen - (prev_seen or self._started))
                             .split('.')[0]})
@@ -238,7 +309,8 @@ class Life360Scanner:
                 lon = float(lon)
                 # Life360 reports accuracy in feet, but Device Tracker expects
                 # gps_accuracy in meters.
-                gps_accuracy=round(float(gps_accuracy)*0.3048)
+                gps_accuracy=round(
+                    convert(float(gps_accuracy), LENGTH_FEET, LENGTH_METERS))
             except (TypeError, ValueError):
                 self._err(dev_id, 'GPS data invalid: {}, {}, {}'.format(
                     lat, lon, gps_accuracy))
@@ -267,8 +339,8 @@ class Life360Scanner:
                 loc_name = place_name
                 # Make sure Home is always seen as exactly as home,
                 # which is the special device_tracker state for home.
-                if loc_name and loc_name.lower() == 'home':
-                    loc_name = 'home'
+                if loc_name and loc_name.lower() == STATE_HOME:
+                    loc_name = STATE_HOME
             else:
                 loc_name = None
 
@@ -289,8 +361,7 @@ class Life360Scanner:
             try:
                 speed = float(raw_speed) * SPEED_FACTOR_MPH
                 if self._hass.config.units.is_metric:
-                    speed = util.distance.convert(
-                        speed, LENGTH_MILES, LENGTH_KILOMETERS)
+                    speed = convert(speed, LENGTH_MILES, LENGTH_KILOMETERS)
                 speed = max(0, round(speed))
             except (TypeError, ValueError):
                 speed = STATE_UNKNOWN
@@ -332,15 +403,13 @@ class Life360Scanner:
                       attributes=attrs, picture=m.get('avatar'))
 
     def _update_life360(self, now=None):
-        excs = (HTTPError, ConnectionError, Timeout, JSONDecodeError)
-
         checked_ids = []
 
         #_LOGGER.debug('Checking members')
         err_key = 'get_circles'
         try:
             circles = self._api.get_circles()
-        except excs as exc:
+        except _API_EXCS as exc:
             self._exc(err_key, exc)
             return
         self._ok(err_key)
@@ -349,8 +418,8 @@ class Life360Scanner:
             err_key = 'get_circle "{}"'.format(
                 circle.get('name') or circle.get('id'))
             try:
-                members = self._api.get_circle(circle['id'])['members']
-            except excs as exc:
+                members = self._api.get_circle_members(circle['id'])
+            except _API_EXCS as exc:
                 self._exc(err_key, exc)
                 continue
             except KeyError:

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -2,7 +2,7 @@
 A Device Tracker platform that retrieves location from Life360.
 
 For more details about this platform, please refer to
-https://github.com/pnbruckner/homeassistant-config#life360py--device_trackerlife360py
+https://github.com/pnbruckner/homeassistant-config#life360-device-tracker-platform
 """
 
 from collections import namedtuple
@@ -31,7 +31,7 @@ from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '2.0.0b2'
+__version__ = '2.0.0b3'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +40,6 @@ DEPENDENCIES = ['zone']
 DEFAULT_FILENAME = 'life360.conf'
 SPEED_FACTOR_MPH = 2.25
 MIN_ZONE_INTERVAL = timedelta(minutes=1)
-ICON_LIFE360_PLACE = 'mdi:map-marker'
 
 _AUTHORIZATION_TOKEN = 'cFJFcXVnYWJSZXRyZTRFc3RldGhlcnVmcmVQdW1hbUV4dWNyRU'\
                        'h1YzptM2ZydXBSZXRSZXN3ZXJFQ2hBUHJFOTZxYWtFZHI0Vg=='
@@ -191,7 +190,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
                 return places
 
     def zone_from_place(place):
-        zone = Zone(hass, *place, ICON_LIFE360_PLACE, DEFAULT_PASSIVE)
+        zone = Zone(hass, *place, None, DEFAULT_PASSIVE)
         zone.entity_id = generate_entity_id(ZN_ENTITY_ID_FORMAT, place.name,
                                             None, hass)
         zone.schedule_update_ha_state()

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -31,7 +31,7 @@ from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '2.0.0b3'
+__version__ = '2.0.0'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/life360.py
+++ b/custom_components/life360.py
@@ -10,12 +10,14 @@ import json
 import os
 import stat
 
-__version__ = '1.0.0'
+__version__ = '1.1.0b1'
 
 _BASE_URL = 'https://api.life360.com/v3/'
 _TOKEN_URL = _BASE_URL + 'oauth2/token.json'
 _CIRCLES_URL = _BASE_URL + 'circles.json'
 _CIRCLE_URL = _BASE_URL + 'circles/{}'
+_CIRCLE_MEMBERS_URL = _CIRCLE_URL + '/members'
+_CIRCLE_PLACES_URL = _CIRCLE_URL + '/places'
 
 class life360(object):
 
@@ -110,3 +112,9 @@ class life360(object):
 
     def get_circle(self, circle_id):
         return self._get(_CIRCLE_URL.format(circle_id))
+
+    def get_circle_members(self, circle_id):
+        return self._get(_CIRCLE_MEMBERS_URL.format(circle_id))['members']
+
+    def get_circle_places(self, circle_id):
+        return self._get(_CIRCLE_PLACES_URL.format(circle_id))['places']

--- a/custom_components/life360.py
+++ b/custom_components/life360.py
@@ -10,7 +10,7 @@ import json
 import os
 import stat
 
-__version__ = '1.1.0b1'
+__version__ = '1.1.0'
 
 _BASE_URL = 'https://api.life360.com/v3/'
 _TOKEN_URL = _BASE_URL + 'oauth2/token.json'

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -1,5 +1,5 @@
 # Life360
-This platform allows you to detect presence using [Life360](http://life360.com/).
+This platform allows you to detect presence using [Life360](http://life360.com/). It can also automatically create Home Assistant zones based on Life360 Places.
 ## Installation
 See [Installing and Updating](custom_updater.md) to use Custom Updater.
 
@@ -37,6 +37,8 @@ device_tracker:
 - **members** (*Optional*): Default is to track all Life360 Members in all Circles. If you'd rather only track a specific set of members, then list them with each member specified as `first,last`, or if they only have one name, then `name`. Names are case insensitive, and extra spaces are ignored (except within a name, like `van Gogh`.) For backwards compatibility, a member with a single name can also be entered as `name,` or `,name`.
 - **interval_seconds** (*Optional*): The default is 12. This defines how often the Life360 server will be queried. The resulting device_tracker entities will actually only be updated when the Life360 server provides new location information for each member.
 - **filename** (*Optional*): The default is life360.conf. The platform will get an authorization token from the Life360 server using your username and password, and it will save the token in a file in the HA config directory (with limited permissions) so that it can reuse it after restarts (and not have to get a new token every time.) If the token eventually expires, a new one will be acquired as needed.
+- **add_zones** (*Optional*): The default is true if `zone_interval` is specified, false otherwise. If true create HA zones based on Life360 Places. Note: Life360 Places named Home (case insensitive) will not be used.
+- **zone_interval** (*Optional*): The default is only to create HA zones at startup (assuming `add_zones` is true.) If specified, will also update HA zones per Life360 Places periodically.
 ## States
 show_as_state | State | Conditions
 -|-|-
@@ -80,6 +82,9 @@ device_tracker:
       - Joe
       - Jones
     interval_seconds: 10
+    add_zones: true
+    zone_interval:
+      minutes: 15
     filename: life360.conf
 ```
 ### Example overdue update automations
@@ -126,6 +131,7 @@ Date | Version | Notes
 20181002 | [1.5.1](https://github.com/pnbruckner/homeassistant-config/blob/6cf17f0a5e02ef556862247ee632d61ce58c7b09/custom_components/device_tracker/life360.py) | Limit speed attribute to non-negative values.
 20181016 | [1.6.0](https://github.com/pnbruckner/homeassistant-config/blob/c24c65a06e78d1ec6b7d11df9f10a7b94a583d12/custom_components/device_tracker/life360.py) | Update as soon as initialization is complete.
 20181025 | [1.6.1](https://github.com/pnbruckner/homeassistant-config/blob/4320553f30b40e08b5bed27552b6242ab2908879/custom_components/device_tracker/life360.py) | __BREAKING CHANGE__: Event names were too long. Shorten them by removing `device_tracker.` prefixes.
+201811xx | [2.0.0]() | Add optional feature to create HA zones based on Life360 Places.
 
 [Life360 Communications Module Release Notes](life360_lib.md#release-notes)
 

--- a/docs/life360_lib.md
+++ b/docs/life360_lib.md
@@ -4,3 +4,4 @@ This module provides the low level communications functionality used by the [Lif
 Date | Version | Notes
 -|:-:|-
 20180907 | [1.0.0](https://github.com/pnbruckner/homeassistant-config/blob/d767bcce0fdff0c9298dc7a010d27af88817eac2/custom_components/life360.py) | Initial support for Custom Updater.
+201811xx | [1.1.0]() | Add get_circle_members and get_circle_places methods.


### PR DESCRIPTION
During startup retrieve Life360 Places and create corresponding zones in HA. Don't use Place if its name is any form of 'home'. Then update periodically (every 15 minutes), removing zones for any Place that has been deleted, and adding zones for any Place that has been added. Bump versions to 1.1.0 for library, and 2.0.0 for device_tracker. Resolves #51.