### PR TITLE
Composite tracker: Accept 'battery_level' and add 'battery_charging'

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -1,7 +1,7 @@
 {
   "device_tracker.composite": {
-    "updated_at": "2018-11-02",
-    "version": "1.5.2",
+    "updated_at": "2018-11-09",
+    "version": "1.6.0",
     "local_location": "/custom_components/device_tracker/composite.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/composite.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/device_tracker/composite.py
+++ b/custom_components/device_tracker/composite.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.event import track_state_change
 from homeassistant import util
 
 
-__version__ = '1.6.0b2'
+__version__ = '1.6.0b3'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -147,10 +147,10 @@ class CompositeScanner:
             except KeyError:
                 gps = None
             gps_accuracy = new_state.attributes.get(ATTR_GPS_ACCURACY)
-            battery = (new_state.attributes.get(ATTR_BATTERY) or
-                       new_state.attributes.get(ATTR_BATTERY_LEVEL))
-            charging = (new_state.attributes.get(ATTR_BATTERY_CHARGING) or
-                        new_state.attributes.get(ATTR_CHARGING))
+            battery = new_state.attributes.get(
+                ATTR_BATTERY, new_state.attributes.get(ATTR_BATTERY_LEVEL))
+            charging = new_state.attributes.get(
+                ATTR_BATTERY_CHARGING, new_state.attributes.get(ATTR_CHARGING))
             # Don't use location_name unless we have to.
             location_name = None
 

--- a/custom_components/device_tracker/composite.py
+++ b/custom_components/device_tracker/composite.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.event import track_state_change
 from homeassistant import util
 
 
-__version__ = '1.6.0b3'
+__version__ = '1.6.0'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/docs/composite.md
+++ b/docs/composite.md
@@ -21,8 +21,8 @@ device_tracker:
       - device_tracker.platform2_me
 ```
 ## Configuration variables
-- **name**: Object ID of composite device: `device_tracker.NAME`
-- **entity_id**: Watched device tracker devices.
+- **name**: Object ID (i.e., part of entity ID after the dot) of composite device. For example, `NAME` would result in an entity ID of `device_tracker.NAME`.
+- **entity_id**: Entity IDs of watched device tracker devices. Can be a single entity ID, a list of entity IDs, or a string containing multiple entity IDs separated by commas.
 ## Watched device notes
 Watched GPS-based devices must have, at a minimum, the following attributes: `latitude`, `longitude` and `gps_accuracy`. If they don't they will not be used.
 
@@ -61,4 +61,4 @@ Date | Version | Notes
 20181019 | [1.5.0](https://github.com/pnbruckner/homeassistant-config/blob/d1fffc42d5c309bc6a99ff74d81469c00a4fa71b/custom_components/device_tracker/composite.py) | Remove initialization delay and update immediately according to current state of entities.
 20181022 | [1.5.1](https://github.com/pnbruckner/homeassistant-config/blob/111ce69063dfeda57f4c62a5207cce7d605c5928/custom_components/device_tracker/composite.py) | Log, but otherwise ignore, invalid states of watched entities during init. Improve "skipping" debug message.
 20181102 | [1.5.2](https://github.com/pnbruckner/homeassistant-config/blob/f29b3db134b15bf6ea30034b4dd5bc7bee281def/custom_components/device_tracker/composite.py) | Slugify name in schema instead of during setup to catch any errors earlier.
-201811xx | [1.6.0]() | In addition to 'battery' attribute, also accept 'battery_level' attribute, and use for 'battery' attribute. Accept either 'battery_charging' or 'charging' attribute and use for new 'battery_charging' attribute. 
+20181109 | [1.6.0]() | In addition to 'battery' attribute, also accept 'battery_level' attribute, and use for 'battery' attribute. Accept either 'battery_charging' or 'charging' attribute and use for new 'battery_charging' attribute. 

--- a/docs/composite.md
+++ b/docs/composite.md
@@ -30,7 +30,7 @@ For watched non-GPS-based devices, which states are used and whether any GPS dat
 
 If a watched device has a `last_seen` attribute, that will be used in the composite device. If not, then `last_updated` from the entity's state will be used instead.
 
-If a watched device has a `battery` attribute, that will be used to update the composite device.
+If a watched device has a `battery` or `battery_level` attribute, that will be used to update the composite device's `battery` attribute. If it has a `battery_charging` or `charging` attribute, that will be used to udpate the composite device's `battery_charging` attribute.
 ## known_devices.yaml
 The watched devices, and the composite device, should all have `track` set to `true`.
 
@@ -41,6 +41,7 @@ Lastly, it is also recommended to _not_ use the native merge feature of the devi
 Attribute | Description
 -|-
 battery | Battery level (in percent, if available.)
+battery_charging | Battery charging status (True/False, if available.)
 entity_id | IDs of entities that have contributed to the state of the composite device.
 gps_accuracy | GPS accuracy radius (in meters, if available.)
 last_entity_id | ID of the last entity to update the composite device.
@@ -60,3 +61,4 @@ Date | Version | Notes
 20181019 | [1.5.0](https://github.com/pnbruckner/homeassistant-config/blob/d1fffc42d5c309bc6a99ff74d81469c00a4fa71b/custom_components/device_tracker/composite.py) | Remove initialization delay and update immediately according to current state of entities.
 20181022 | [1.5.1](https://github.com/pnbruckner/homeassistant-config/blob/111ce69063dfeda57f4c62a5207cce7d605c5928/custom_components/device_tracker/composite.py) | Log, but otherwise ignore, invalid states of watched entities during init. Improve "skipping" debug message.
 20181102 | [1.5.2](https://github.com/pnbruckner/homeassistant-config/blob/f29b3db134b15bf6ea30034b4dd5bc7bee281def/custom_components/device_tracker/composite.py) | Slugify name in schema instead of during setup to catch any errors earlier.
+201811xx | [1.6.0]() | In addition to 'battery' attribute, also accept 'battery_level' attribute, and use for 'battery' attribute. Accept either 'battery_charging' or 'charging' attribute and use for new 'battery_charging' attribute. 


### PR DESCRIPTION
In addition to 'battery' attribute, also accept 'battery_level' attribute, and use for see method's battery parameter which ultimately becomes device_tracker entity's 'battery' attribute. Accept either 'battery_charging' or 'charging' attribute and use as device_tracker entity's 'battery_charging' attribute. Bump to version 1.6.0. Resolves #60.