### PR TITLE
Life360: (BREAKING CHANGE) Change 'charging' to 'battery_charging' and make 'battery' an int

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -8,8 +8,8 @@
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/composite.md#release-notes"
   },
   "device_tracker.life360": {
-    "updated_at": "2018-11-02",
-    "version": "2.0.0",
+    "updated_at": "2018-11-09",
+    "version": "2.1.0",
     "local_location": "/custom_components/device_tracker/life360.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/life360.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -32,7 +32,7 @@ from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '2.1.0b1'
+__version__ = '2.1.0'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -21,8 +21,9 @@ from homeassistant.components.zone import (
     DEFAULT_PASSIVE, ENTITY_ID_FORMAT as ZN_ENTITY_ID_FORMAT, HOME_ZONE, Zone)
 from homeassistant.components.zone.zone import active_zone
 from homeassistant.const import (
-    CONF_FILENAME, CONF_PASSWORD, CONF_PREFIX, CONF_USERNAME, LENGTH_FEET,
-    LENGTH_KILOMETERS, LENGTH_METERS, LENGTH_MILES, STATE_HOME, STATE_UNKNOWN)
+    ATTR_BATTERY_CHARGING, CONF_FILENAME, CONF_PASSWORD, CONF_PREFIX,
+    CONF_USERNAME, LENGTH_FEET, LENGTH_KILOMETERS, LENGTH_METERS, LENGTH_MILES,
+    STATE_HOME, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.event import track_time_interval
@@ -31,7 +32,7 @@ from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '2.0.0'
+__version__ = '2.1.0b1'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,7 +60,6 @@ SHOW_AS_STATE_OPTS = [SHOW_DRIVING, SHOW_MOVING, SHOW_PLACES]
 
 ATTR_ADDRESS = 'address'
 ATTR_AT_LOC_SINCE = 'at_loc_since'
-ATTR_CHARGING = 'charging'
 ATTR_DRIVING = SHOW_DRIVING
 ATTR_LAST_SEEN = 'last_seen'
 ATTR_MOVING = SHOW_MOVING
@@ -385,7 +385,7 @@ class Life360Scanner:
             attrs = {
                 ATTR_ADDRESS: address,
                 ATTR_AT_LOC_SINCE: utc_attr_from_ts(loc.get('since')),
-                ATTR_CHARGING: bool_attr_from_int(loc.get('charge')),
+                ATTR_BATTERY_CHARGING: bool_attr_from_int(loc.get('charge')),
                 ATTR_DRIVING: driving,
                 ATTR_LAST_SEEN: last_seen,
                 ATTR_MOVING: moving,
@@ -404,7 +404,7 @@ class Life360Scanner:
                     loc_name = SHOW_MOVING.capitalize()
 
             try:
-                battery = float(loc.get('battery'))
+                battery = int(float(loc.get('battery')))
             except (TypeError, ValueError):
                 battery = None
 

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -56,7 +56,7 @@ Attribute | Description
 -|-
 address | Address of current location, or None.
 at_loc_since | Date and time when first at current location (in UTC.)
-charging | Device is charging (True/False.)
+battery_charging | Device is charging (True/False.)
 driving | Device movement indicates driving (True/False.)
 entity_picture | Member's "avatar" if one is provided by Life360.
 last_seen | Date and time when Life360 last updated your location (in UTC.)
@@ -131,6 +131,7 @@ Date | Version | Notes
 20181002 | [1.5.1](https://github.com/pnbruckner/homeassistant-config/blob/6cf17f0a5e02ef556862247ee632d61ce58c7b09/custom_components/device_tracker/life360.py) | Limit speed attribute to non-negative values.
 20181016 | [1.6.0](https://github.com/pnbruckner/homeassistant-config/blob/c24c65a06e78d1ec6b7d11df9f10a7b94a583d12/custom_components/device_tracker/life360.py) | Update as soon as initialization is complete.
 20181025 | [1.6.1](https://github.com/pnbruckner/homeassistant-config/blob/4320553f30b40e08b5bed27552b6242ab2908879/custom_components/device_tracker/life360.py) | __BREAKING CHANGE__: Event names were too long. Shorten them by removing `device_tracker.` prefixes.
-201811xx | [2.0.0](https://github.com/pnbruckner/homeassistant-config/blob/da9bdcf9923f8e93820f23a49289af35c6371a71/custom_components/device_tracker/life360.py) | Add optional feature to create HA zones based on Life360 Places.
+20181102 | [2.0.0](https://github.com/pnbruckner/homeassistant-config/blob/da9bdcf9923f8e93820f23a49289af35c6371a71/custom_components/device_tracker/life360.py) | Add optional feature to create HA zones based on Life360 Places.
+20181109 | [2.1.0]() | Change charging attribute to the more common battery_charging attribute. Instead of a float, make battery attribute an int like it should have been originally.
 
 [Life360 Communications Module Release Notes](life360_lib.md#release-notes)


### PR DESCRIPTION
Change charging attribute to the more common battery_charging attribute. Instead of a float, make battery attribute an int like it should have been originally. Bump to 2.1.0. Resolves #61.