### PR TITLE
Illuminance: Fixes bug with 0.85

### DIFF
--- a/custom_components/sensor/illuminance.py
+++ b/custom_components/sensor/illuminance.py
@@ -17,7 +17,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN, PLATFORM_SCHEMA, SCAN_INTERVAL)
 from homeassistant.components.sensor.darksky import (
-    CONF_ATTRIBUTION as DSS_ATTRIBUTION)
+    ATTRIBUTION as DSS_ATTRIBUTION)
 from homeassistant.components.sensor.yr import (
     CONF_ATTRIBUTION as YRS_ATTRIBUTION)
 from homeassistant.components.weather.darksky import (


### PR DESCRIPTION
Thu Jan 10 2019 10:59:10 GMT-0600 (CST)
Error loading custom_components.sensor.illuminance. Make sure all dependencies are installed
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/homeassistant/loader.py", line 92, in get_component
    module = importlib.import_module(path)
  File "/usr/local/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/config/custom_components/sensor/illuminance.py", line 19, in <module>
    from homeassistant.components.sensor.darksky import (
ImportError: cannot import name 'CONF_ATTRIBUTION'