### PR TITLE
Illuminance: Fixes bug caused by HA 0.85 release

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -16,8 +16,8 @@
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/life360.md#release-notes"
   },
   "sensor.illuminance": {
-    "updated_at": "2018-10-28",
-    "version": "2.0.0",
+    "updated_at": "2019-01-11",
+    "version": "2.0.1",
     "local_location": "/custom_components/sensor/illuminance.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/sensor/illuminance.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/sensor/illuminance.py
+++ b/custom_components/sensor/illuminance.py
@@ -38,7 +38,7 @@ from homeassistant.helpers.event import (
 from homeassistant.helpers.sun import get_astral_event_date
 import homeassistant.util.dt as dt_util
 
-__version__ = '2.0.1b1'
+__version__ = '2.0.1'
 
 DEFAULT_NAME = 'Illuminance'
 MIN_SCAN_INTERVAL = dt.timedelta(minutes=5)

--- a/custom_components/sensor/illuminance.py
+++ b/custom_components/sensor/illuminance.py
@@ -16,8 +16,12 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN, PLATFORM_SCHEMA, SCAN_INTERVAL)
-from homeassistant.components.sensor.darksky import (
-    ATTRIBUTION as DSS_ATTRIBUTION)
+try:
+    from homeassistant.components.sensor.darksky import (
+        ATTRIBUTION as DSS_ATTRIBUTION)
+except ImportError:
+    from homeassistant.components.sensor.darksky import (
+        CONF_ATTRIBUTION as DSS_ATTRIBUTION)
 from homeassistant.components.sensor.yr import (
     CONF_ATTRIBUTION as YRS_ATTRIBUTION)
 from homeassistant.components.weather.darksky import (
@@ -34,7 +38,7 @@ from homeassistant.helpers.event import (
 from homeassistant.helpers.sun import get_astral_event_date
 import homeassistant.util.dt as dt_util
 
-__version__ = '2.0.0'
+__version__ = '2.0.1b1'
 
 DEFAULT_NAME = 'Illuminance'
 MIN_SCAN_INTERVAL = dt.timedelta(minutes=5)

--- a/docs/illuminance.md
+++ b/docs/illuminance.md
@@ -83,3 +83,4 @@ Date | Version | Notes
 -|:-:|-
 20180907 | [1.0.0](https://github.com/pnbruckner/homeassistant-config/blob/d767bcce0fdff0c9298dc7a010d27af88817eac2/custom_components/sensor/illuminance.py) | Initial support for Custom Updater.
 20181028 | [2.0.0](https://github.com/pnbruckner/homeassistant-config/blob/e4fbbfe5ccc48cc08045226197c5c27767ec081e/custom_components/sensor/illuminance.py) | Add support for using Dark Sky or YR entity as source of weather conditions. For WU, no longer get sunrise/sunset data from the server, just use HA’s sun data.
+20190111 | [2.0.1]() | Fix bug caused by change in Dark Sky Sensor in HA 0.85 release.


### PR DESCRIPTION
In the 0.85 release, homeassistant.components.sensor.darksky changed CONF_ATTRIBUTION to ATTRIBUTION. Change to accept old and new module attribute. Fixes #83.