### PR TITLE
Life360 & Composite Trackers: Add option to show datetimes in UTC, local timezone or timezone where device is located

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -1,15 +1,15 @@
 {
   "device_tracker.composite": {
-    "updated_at": "2018-11-09",
-    "version": "1.6.0",
+    "updated_at": "2019-01-23",
+    "version": "1.7.0",
     "local_location": "/custom_components/device_tracker/composite.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/composite.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/composite.md#release-notes"
   },
   "device_tracker.life360": {
-    "updated_at": "2018-11-30",
-    "version": "2.3.1",
+    "updated_at": "2019-01-23",
+    "version": "2.4.0",
     "local_location": "/custom_components/device_tracker/life360.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/life360.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/device_tracker/composite.py
+++ b/custom_components/device_tracker/composite.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.event import track_state_change
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '1.7.0b5'
+__version__ = '1.7.0'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/device_tracker/composite.py
+++ b/custom_components/device_tracker/composite.py
@@ -21,13 +21,13 @@ from homeassistant.const import (
     ATTR_BATTERY_CHARGING, ATTR_BATTERY_LEVEL,
     ATTR_ENTITY_ID, ATTR_GPS_ACCURACY, ATTR_LATITUDE, ATTR_LONGITUDE,
     ATTR_STATE, CONF_ENTITY_ID, CONF_NAME, EVENT_HOMEASSISTANT_START,
-    STATE_HOME, STATE_NOT_HOME, STATE_ON)
+    STATE_HOME, STATE_NOT_HOME, STATE_ON, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_state_change
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '1.7.0b2'
+__version__ = '1.7.0b3'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/device_tracker/composite.py
+++ b/custom_components/device_tracker/composite.py
@@ -27,19 +27,19 @@ from homeassistant.helpers.event import track_state_change
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '1.7.0b3'
+__version__ = '1.7.0b4'
 
 _LOGGER = logging.getLogger(__name__)
 
 REQUIREMENTS = ['timezonefinderL==2.*']
 
-CONF_TIMES_AS = 'times_as'
+CONF_TIME_AS = 'time_as'
 
 TZ_UTC = 'utc'
 TZ_LOCAL = 'local'
 TZ_DEVICE = 'device'
 # First item in list is default.
-TIMES_AS_OPTS = [TZ_UTC, TZ_LOCAL, TZ_DEVICE]
+TIME_AS_OPTS = [TZ_UTC, TZ_LOCAL, TZ_DEVICE]
 
 ATTR_CHARGING = 'charging'
 ATTR_LAST_SEEN = 'last_seen'
@@ -60,8 +60,8 @@ SOURCE_TYPE_NON_GPS = (
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_NAME): cv.slugify,
     vol.Required(CONF_ENTITY_ID): cv.entity_ids,
-    vol.Optional(CONF_TIMES_AS, default=TIMES_AS_OPTS[0]):
-        vol.In(TIMES_AS_OPTS),
+    vol.Optional(CONF_TIME_AS, default=TIME_AS_OPTS[0]):
+        vol.In(TIME_AS_OPTS),
 })
 
 
@@ -82,8 +82,8 @@ class CompositeScanner:
                 STATE: None}
         self._dev_id = config[CONF_NAME]
         self._entity_id = ENTITY_ID_FORMAT.format(self._dev_id)
-        self._times_as = config[CONF_TIMES_AS]
-        if self._times_as == TZ_DEVICE:
+        self._time_as = config[CONF_TIME_AS]
+        if self._time_as == TZ_DEVICE:
             from timezonefinderL import TimezoneFinder
             self._tf = TimezoneFinder()
         self._lock = threading.Lock()
@@ -130,9 +130,9 @@ class CompositeScanner:
             if entity[SOURCE_TYPE] in SOURCE_TYPE_NON_GPS)
 
     def _dt_attr_from_utc(self, utc, tz):
-        if self._times_as == TZ_UTC:
+        if self._time_as == TZ_UTC:
             return utc
-        if self._times_as == TZ_LOCAL or not tz:
+        if self._time_as == TZ_LOCAL or not tz:
             return dt_util.as_local(utc)
         return utc.astimezone(tz)
 
@@ -259,7 +259,7 @@ class CompositeScanner:
                 return
 
             tz = None
-            if self._times_as == TZ_DEVICE:
+            if self._time_as == TZ_DEVICE:
                 tzname = None
                 if gps:
                     # timezone_at will return a string or None.

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -32,7 +32,7 @@ from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '2.4.0b5'
+__version__ = '2.4.0'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/docs/composite.md
+++ b/docs/composite.md
@@ -18,12 +18,20 @@ Then add the desired configuration. Here is an example of a typical configuratio
 device_tracker:
   - platform: composite
     name: me
+    time_as: device_or_local
     entity_id:
       - device_tracker.platform1_me
       - device_tracker.platform2_me
 ```
+### numpy on Raspberry Pi
+To determine time zone from GPS coordinates (see `time_as` configuration variable below) the package [timezonefinderL](https://pypi.org/project/timezonefinderL/) is used. That package requires the package [numpy](https://pypi.org/project/numpy/). These will both be installed automatically by HA. Note, however, that numpy on Pi _usually_ requires libatlas to be installed. (See [this web page](https://www.raspberrypi.org/forums/viewtopic.php?t=207058) for more details.) It can be installed using this command:
+```
+sudo apt install libatlas3-base
+```
+>Note: This is the same step that would be required if using a standard HA component that uses numpy (such as the [Trend Binary Sensor](https://www.home-assistant.io/components/binary_sensor.trend/)), and is only required if you use `device_or_utc` or `device_or_local` for `time_as`.
 ## Configuration variables
 - **name**: Object ID (i.e., part of entity ID after the dot) of composite device. For example, `NAME` would result in an entity ID of `device_tracker.NAME`.
+- **time_as** (*Optional*): One of `utc`, `local`, `device_or_utc` or `device_or_local`. Default is `utc` which shows time attributes in UTC. `local` shows time attributes per HA's `time_zone` configuration. `device_or_utc` and `device_or_local` attempt to determine the time zone in which the device is located based on its GPS coordinates. The name of the time zone (or `unknown`) will be shown in a new attribute named `time_zone`. If the time zone can be determined, then time attributes will be shown in that time zone. If the time zone cannot be determined, then time attributes will be shown in UTC if `device_or_utc` is selected, or in HA's local time zone if `device_or_local` is selected.
 - **entity_id**: Entity IDs of watched device tracker devices. Can be a single entity ID, a list of entity IDs, or a string containing multiple entity IDs separated by commas.
 ## Watched device notes
 Watched GPS-based devices must have, at a minimum, the following attributes: `latitude`, `longitude` and `gps_accuracy`. If they don't they will not be used.
@@ -51,6 +59,7 @@ last_seen | Date and time when current location information was last updated.
 latitude | Latitude of current location (if available.)
 longitude | Longitude of current location (if available.)
 source_type | Source of current location information: `binary_sensor`, `bluetooth`, `bluetooth_le`, `gps` or `router`.
+time_zone | The name of the time zone in which the device is located, or `unknown` if it cannot be determined. Only exists if `device_or_utc` or `device_or_local` is chosen for `time_as`.
 ## Release Notes
 Date | Version | Notes
 -|:-:|-
@@ -64,3 +73,4 @@ Date | Version | Notes
 20181022 | [1.5.1](https://github.com/pnbruckner/homeassistant-config/blob/111ce69063dfeda57f4c62a5207cce7d605c5928/custom_components/device_tracker/composite.py) | Log, but otherwise ignore, invalid states of watched entities during init. Improve "skipping" debug message.
 20181102 | [1.5.2](https://github.com/pnbruckner/homeassistant-config/blob/f29b3db134b15bf6ea30034b4dd5bc7bee281def/custom_components/device_tracker/composite.py) | Slugify name in schema instead of during setup to catch any errors earlier.
 20181109 | [1.6.0](https://github.com/pnbruckner/homeassistant-config/blob/a38ddea71232053e6f8824822e31cd5060801334/custom_components/device_tracker/composite.py) | In addition to 'battery' attribute, also accept 'battery_level' attribute, and use for 'battery' attribute. Accept either 'battery_charging' or 'charging' attribute and use for new 'battery_charging' attribute. 
+201901xx | [1.7.0]() | Add `time_as` option.

--- a/docs/composite.md
+++ b/docs/composite.md
@@ -60,6 +60,38 @@ latitude | Latitude of current location (if available.)
 longitude | Longitude of current location (if available.)
 source_type | Source of current location information: `binary_sensor`, `bluetooth`, `bluetooth_le`, `gps` or `router`.
 time_zone | The name of the time zone in which the device is located, or `unknown` if it cannot be determined. Only exists if `device_or_utc` or `device_or_local` is chosen for `time_as`.
+## Examples
+### Time zone examples
+This example assumes `time_as` is set to `device_or_utc` or `device_or_local`. It determines the difference between the time zone in which the device is located and the `time_zone` in HA's configuration. A positive value means the device's time zone is ahead of (or later than, or east of) the local time zone.
+```yaml
+sensor:
+  - platform: template
+    sensors:
+      my_tz_offset:
+        friendly_name: My time zone offset
+        unit_of_measurement: hr
+        value_template: >
+          {% set state = states.device_tracker.me %}
+          {% if state.attributes is defined and
+                state.attributes.time_zone is defined and
+                state.attributes.time_zone != 'unknown' %}
+            {% set n = now() %}
+            {{ (n.astimezone(state.attributes.last_seen.tzinfo).utcoffset() -
+                n.utcoffset()).total_seconds()/3600 }}
+          {% else %}
+            unknown
+          {% endif %}
+```
+This example converts a time attribute to the local time zone. It works no matter which time zone the attribute is in.
+```yaml
+sensor:
+  - platform: template
+    sensors:
+      my_last_seen_local:
+        friendly_name: My last_seen time in local time zone
+        value_template: >
+          {{ state_attr('device_tracker.me', last_seen').astimezone(now().tzinfo) }}
+```
 ## Release Notes
 Date | Version | Notes
 -|:-:|-

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -22,7 +22,7 @@ device_tracker:
     show_as_state: driving, moving, places
     driving_speed: 18
     max_gps_accuracy: 200
-    time_as: device
+    time_as: device_or_local
     max_update_wait:
       minutes: 45
 ```
@@ -86,7 +86,7 @@ device_tracker:
     home_place: Home
     driving_speed: 18
     max_gps_accuracy: 200
-    time_as: device
+    time_as: device_or_local
     max_update_wait:
       minutes: 45
     members:


### PR DESCRIPTION
Add new config item - times_as_local - to cause datetime attributes - such as last_seen & at_loc_since - to be in the local timezone as opposed to UTC. Default to False. Also for life360, move the import of the life360 PyPI module into a try block in case it didn't get installed to handle that scenario better. Resolves #69.