### PR TITLE
Life360: Add warning and error thresholds for comm errors

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -8,8 +8,8 @@
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/composite.md#release-notes"
   },
   "device_tracker.life360": {
-    "updated_at": "2019-01-23",
-    "version": "2.4.0",
+    "updated_at": "2019-01-29",
+    "version": "2.5.0",
     "local_location": "/custom_components/device_tracker/life360.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/life360.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -32,7 +32,7 @@ from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '2.5.0b1'
+__version__ = '2.5.0b2'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,12 +49,14 @@ _AUTHORIZATION_TOKEN = 'cFJFcXVnYWJSZXRyZTRFc3RldGhlcnVmcmVQdW1hbUV4dWNyRU'\
 
 CONF_ADD_ZONES = 'add_zones'
 CONF_DRIVING_SPEED = 'driving_speed'
+CONF_ERROR_THRESHOLD = 'error_threshold'
 CONF_HOME_PLACE = 'home_place'
 CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
 CONF_MAX_UPDATE_WAIT = 'max_update_wait'
 CONF_MEMBERS = 'members'
 CONF_SHOW_AS_STATE = 'show_as_state'
 CONF_TIME_AS = 'time_as'
+CONF_WARNING_THRESHOLD = 'warning_threshold'
 CONF_ZONE_INTERVAL = 'zone_interval'
 
 SHOW_DRIVING = 'driving'
@@ -97,6 +99,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(cv.time_period, vol.Range(min=MIN_ZONE_INTERVAL)),
     vol.Optional(CONF_TIME_AS, default=TIME_AS_OPTS[0]):
         vol.In(TIME_AS_OPTS),
+    vol.Optional(CONF_WARNING_THRESHOLD): cv.positive_int,
+    vol.Optional(CONF_ERROR_THRESHOLD, default = 0): cv.positive_int,
 })
 
 _API_EXCS = (HTTPError, ConnectionError, Timeout, JSONDecodeError)
@@ -148,14 +152,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
         return False
     _LOGGER.debug('Life360 communication successful!')
 
-    show_as_state = config[CONF_SHOW_AS_STATE]
-    home_place = config[CONF_HOME_PLACE].lower()
-    max_gps_accuracy = config.get(CONF_MAX_GPS_ACCURACY)
-    max_update_wait = config.get(CONF_MAX_UPDATE_WAIT)
-    prefix = config.get(CONF_PREFIX)
     members = config.get(CONF_MEMBERS)
-    driving_speed = config.get(CONF_DRIVING_SPEED)
-    time_as = config[CONF_TIME_AS]
     _LOGGER.debug('Configured members = {}'.format(members))
 
     if members:
@@ -174,6 +171,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
             _LOGGER.error('No listed member names were valid')
             return False
 
+    home_place = config[CONF_HOME_PLACE].lower()
     Place = namedtuple('Place', ['name', 'latitude', 'longitude', 'radius'])
 
     def get_places():
@@ -237,30 +235,33 @@ def setup_scanner(hass, config, see, discovery_info=None):
             _LOGGER.debug('Will check Places every: {}'.format(zone_interval))
             track_time_interval(hass, zones_from_places, zone_interval)
 
-    Life360Scanner(hass, see, interval, show_as_state, home_place,
-                   max_gps_accuracy, max_update_wait, prefix, members,
-                   driving_speed, time_as, api)
+    Life360Scanner(hass, config, see, interval, home_place, members, api)
     return True
 
 class Life360Scanner:
-    def __init__(self, hass, see, interval, show_as_state, home_place,
-                 max_gps_accuracy, max_update_wait, prefix, members,
-                 driving_speed, time_as, api):
+    def __init__(self, hass, config, see, interval, home_place, members, api):
         self._hass = hass
         self._see = see
-        self._show_as_state = show_as_state
+        self._show_as_state = config[CONF_SHOW_AS_STATE]
         self._home_place = home_place
-        self._max_gps_accuracy = max_gps_accuracy
-        self._max_update_wait = max_update_wait
+        self._max_gps_accuracy = config.get(CONF_MAX_GPS_ACCURACY)
+        self._max_update_wait = config.get(CONF_MAX_UPDATE_WAIT)
+        prefix = config.get(CONF_PREFIX)
         self._prefix = '' if not prefix else prefix + '_'
         self._members = members
-        self._driving_speed = driving_speed
-        self._time_as = time_as
+        self._driving_speed = config.get(CONF_DRIVING_SPEED)
+        self._time_as = config[CONF_TIME_AS]
         self._api = api
 
         self._errs = {}
-        self._warning_threshold = 0
-        self._error_threshold = 2
+        self._error_threshold = config[CONF_ERROR_THRESHOLD]
+        self._warning_threshold = config.get(
+            CONF_WARNING_THRESHOLD, self._error_threshold)
+        if self._warning_threshold > self._error_threshold:
+            _LOGGER.warning('Ignoring {}: ({}) > {} ({})'.format(
+                CONF_WARNING_THRESHOLD, self._warning_threshold,
+                CONF_ERROR_THRESHOLD, self._error_threshold))
+
         self._max_errs = self._error_threshold + 2
         self._dev_data = {}
         if self._time_as in [TZ_DEVICE_UTC, TZ_DEVICE_LOCAL]:

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -32,7 +32,7 @@ from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '2.5.0b2'
+__version__ = '2.5.0'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -105,7 +105,7 @@ device_tracker:
     zone_interval:
       minutes: 15
     filename: life360.conf
-    # Set comm error threshold so first is not logged,
+    # Set comm error thresholds so first is not logged,
     # second is logged as a WARNING, and third and fourth
     # are logged as ERRORs.
     warning_threshold: 1
@@ -193,3 +193,4 @@ Date | Version | Notes
 20181130 | [2.3.0](https://github.com/pnbruckner/homeassistant-config/blob/784cbda88eaa3f7010029597afd449d14300a1ea/custom_components/device_tracker/life360.py) | Add optional `home_place` configuration variable.
 20181130 | [2.3.1](https://github.com/pnbruckner/homeassistant-config/blob/a568b8e84c3ea20386af8ddd618d878095ee35cb/custom_components/device_tracker/life360.py) | Do not add zone for Life360 Places whose name matches `home_place`.
 20190123 | [2.4.0](https://github.com/pnbruckner/homeassistant-config/blob/0f0254c1137255662e1fe53e0d08a8bbf4e2f1b2/custom_components/device_tracker/life360.py) | Add `time_as` option.
+201901xx | [2.5.0]() | Add `waring_threshold` and `error_threshold`.


### PR DESCRIPTION
Communication errors can often happen during normal use. As long as there aren't too many in a row, things seem to work ok. Filter comm errors better by adding two thresholds: warning and error. If the number of times a particular error happens in a row is greater than the error threshold, then log it as an error. If not, but it's greater than the warning threshold, then log it as a warning. Default both thresholds to zero so without a config change it works the way it used to work. Also make "Authenticating" log message INFO instead of DEBUG. Bump to 2.5.0.