### PR TITLE
Life360: Add include_home_zone choice for add_zones

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -8,7 +8,7 @@
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/composite.md#release-notes"
   },
   "device_tracker.life360": {
-    "updated_at": "2019-02-07",
+    "updated_at": "2019-02-08",
     "version": "2.6.0",
     "local_location": "/custom_components/device_tracker/life360.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/life360.py",

--- a/custom_components.json
+++ b/custom_components.json
@@ -8,8 +8,8 @@
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/composite.md#release-notes"
   },
   "device_tracker.life360": {
-    "updated_at": "2019-01-29",
-    "version": "2.5.0",
+    "updated_at": "2019-02-07",
+    "version": "2.6.0",
     "local_location": "/custom_components/device_tracker/life360.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/life360.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -35,7 +35,7 @@ from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '2.6.0b6'
+__version__ = '2.6.0'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -34,7 +34,7 @@ from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '2.6.0b2'
+__version__ = '2.6.0b3'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ CONF_TIME_AS = 'time_as'
 CONF_WARNING_THRESHOLD = 'warning_threshold'
 CONF_ZONE_INTERVAL = 'zone_interval'
 
-INCLUDING_HOME = 'include_home_place'
+INCLUDE_HOME = 'include_home'
 SHOW_DRIVING = 'driving'
 SHOW_MOVING = 'moving'
 SHOW_PLACES = 'places'
@@ -103,7 +103,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         cv.ensure_list, [cv.string]),
     vol.Optional(CONF_DRIVING_SPEED): vol.Coerce(float),
     vol.Optional(CONF_ADD_ZONES):
-        vol.Any(INCLUDING_HOME, cv.boolean),
+        vol.Any(INCLUDE_HOME, cv.boolean),
     vol.Optional(CONF_ZONE_INTERVAL):
         vol.All(cv.time_period, vol.Range(min=MIN_ZONE_INTERVAL)),
     vol.Optional(CONF_TIME_AS, default=TIME_AS_OPTS[0]):
@@ -238,7 +238,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
         # If a "Home Place" was found, and user wants to update zone.home with
         # it, and if it is indeed different, then update zone.home.
-        if home_place and add_zones == INCLUDING_HOME:
+        if home_place and add_zones == INCLUDE_HOME:
             hz_attrs = hass.states.get(ENTITY_ID_HOME).attributes
             if home_place != Place(hz_attrs[ATTR_FRIENDLY_NAME],
                                    hz_attrs[ATTR_LATITUDE],

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -205,4 +205,4 @@ Date | Version | Notes
 20181130 | [2.3.1](https://github.com/pnbruckner/homeassistant-config/blob/a568b8e84c3ea20386af8ddd618d878095ee35cb/custom_components/device_tracker/life360.py) | Do not add zone for Life360 Places whose name matches `home_place`.
 20190123 | [2.4.0](https://github.com/pnbruckner/homeassistant-config/blob/0f0254c1137255662e1fe53e0d08a8bbf4e2f1b2/custom_components/device_tracker/life360.py) | Add `time_as` option.
 20190129 | [2.5.0](https://github.com/pnbruckner/homeassistant-config/blob/93ed07bb61f40dfdc36e970968726ba16a8510a3/custom_components/device_tracker/life360.py) | Add `waring_threshold` and `error_threshold`.
-201902xx | [2.6.0]() | Add `only_home`, `except_home` and `all` options for `add_zones`, and add `device_tracker.life360_zones_from_places` service. Update life360 package from PyPI to 2.1.0.
+20190208 | [2.6.0]() | Add `only_home`, `except_home` and `all` options for `add_zones`, and add `device_tracker.life360_zones_from_places` service. Update life360 package from PyPI to 2.1.0.

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -78,6 +78,14 @@ wifi_on | Device WiFi is turned on (`true`/`false`.)
 Service | Description
 -|-
 `device_tracker.life360_zones_from_places` | Update HA zones from Life360 Places per `add_zones` configuration. Only available if `add_zones` is not `false`.
+## Home - Home Assistant vs Life360
+Normally HA device trackers are "Home" when they enter `zone.home`. (See [Zone documentation](https://www.home-assistant.io/components/zone/#home-zone) for details about how this zone is defined.) And Life360 normally considers your device "Home" when it enters the Place that coincides with your home (i.e., the Life360 "Home Place.") Since the definitions of these areas can be different, this can lead to a disagreement between HA and Life360 as to whether or not you're "Home." There are three basic ways to avoid this situation.
+
+The first is to manually make sure these two areas are defined the same -- i.e., same location and radius.
+
+The second is to include `places` in the HA life360 `show_as_state` configuration variable. Whenever Life360 determines you are in its Home Place the corresponding HA device tracker's state will be set to `home` (see `home_place` config variable.) This, however, requires `zone.home` to be entirely contained within Life360's Home Place. If it isn't, and if you enter `zone.home` but not Life360's Home Place, then it is still possible for the two systems to disagree.
+
+The third, and probably the easiest and most foolproof way, is to configure this platform to automatically update `zone.home` to be the exact same size, and at the exact same location, as Life360's Home Place. To enable this, set `add_zones` to `include_home`.
 ## Communication Errors
 It is not uncommon for communication errors to occur between Home Assistant and the Life360 server. This can happen for many reasons, including Internet connection issues, Life360 server load, etc. However, in most cases, they are temporary and do not significantly affect the ability to keep device_tracker entities up to date.
 

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -74,14 +74,14 @@ time_zone | The name of the time zone in which the device is located, or `unknow
 wifi_on | Device WiFi is turned on (`true`/`false`.)
 
 >__NOTE__: `entity_picture` will only be set to Member's avatar the _very first time_ the device is seen. This is just how the device_tracker component-level code works. If an avatar is changed later the HA device_tracker entity's picture will not be updated automatically. If you want HA to use the new avatar you will need to manually edit known_devices.yaml.
-## Communication Errors
-It is not uncommon for communication errors to occur between Home Assistant and the Life360 server. This can happen for many reasons, including Internet connection issues, Life360 server load, etc. However, in most cases, they are temporary and do not significantly affect the ability to keep device_tracker entities up to date.
-
-Therefore an optional filtering mechanism has been implemented to prevent inconsequential communication errors from filling the log, while still logging unusual error activity. Two thresholds are defined: `warning_threshold` and `error_threshold`. When a particular type of communication error happens on consecutive update cycles, it will not be logged until the number of occurences exceeds these thresholds. When the number exceeds `warning_threshold` (but does not exceed `error_threshold`, and only if `warning_threshold` is defined) it will be logged as a WARNING. Once the number exceeds `error_threshold` it will be logged as an ERROR. Only two consecutive communication errors of a particular type will be logged as an ERROR, after which it will no longer be logged until it stops occuring.
 ## Services
 Service | Description
 -|-
 `device_tracker.life360_zones_from_places` | Update HA zones from Life360 Places per `add_zones` configuration. Only available if `add_zones` is not `false`.
+## Communication Errors
+It is not uncommon for communication errors to occur between Home Assistant and the Life360 server. This can happen for many reasons, including Internet connection issues, Life360 server load, etc. However, in most cases, they are temporary and do not significantly affect the ability to keep device_tracker entities up to date.
+
+Therefore an optional filtering mechanism has been implemented to prevent inconsequential communication errors from filling the log, while still logging unusual error activity. Two thresholds are defined: `warning_threshold` and `error_threshold`. When a particular type of communication error happens on consecutive update cycles, it will not be logged until the number of occurences exceeds these thresholds. When the number exceeds `warning_threshold` (but does not exceed `error_threshold`, and only if `warning_threshold` is defined) it will be logged as a WARNING. Once the number exceeds `error_threshold` it will be logged as an ERROR. Only two consecutive communication errors of a particular type will be logged as an ERROR, after which it will no longer be logged until it stops occuring.
 ## Examples
 ### Example full configuration
 ```yaml

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -31,8 +31,8 @@ sudo apt install libatlas3-base
 >Note: This is the same step that would be required if using a standard HA component that uses numpy (such as the [Trend Binary Sensor](https://www.home-assistant.io/components/binary_sensor.trend/)), and is only required if you use `device_or_utc` or `device_or_local` for `time_as`.
 ## Configuration variables
 - **username**: Your Life360 username.
-- **password**: Your Life360 password.
 
+- **password**: Your Life360 password.
 - **add_zones** (*Optional*): Can be `true`, `false` or `include_home`. The default is `false` if `zone_interval` is _not_ specified, `true` if `zone_interval` _is_ specified. If `true` or `include_home`, create HA zones based on Life360 Places. Life360 Places whose names match `home_place` (case insensitive) will only be used when set to `include_home`.
 - **driving_speed** (*MPH or KPH, depending on HA's unit system configuration, Optional*): The minimum speed at which the device is considered to be "driving" (and which will also set the `driving` [attribute](#additional-attributes) to `true`. See also `Driving` state in [chart](#states) below.)
 - **error_threshold** (*Optional*): The default is zero. See [Communication Errors](#communication-errors) for a detailed description.

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -31,7 +31,6 @@ sudo apt install libatlas3-base
 >Note: This is the same step that would be required if using a standard HA component that uses numpy (such as the [Trend Binary Sensor](https://www.home-assistant.io/components/binary_sensor.trend/)), and is only required if you use `device_or_utc` or `device_or_local` for `time_as`.
 ## Configuration variables
 - **username**: Your Life360 username.
-
 - **password**: Your Life360 password.
 - **add_zones** (*Optional*): Can be `true`, `false` or `include_home`. The default is `false` if `zone_interval` is _not_ specified, `true` if `zone_interval` _is_ specified. If `true` or `include_home`, create HA zones based on Life360 Places. Life360 Places whose names match `home_place` (case insensitive) will only be used when set to `include_home`.
 - **driving_speed** (*MPH or KPH, depending on HA's unit system configuration, Optional*): The minimum speed at which the device is considered to be "driving" (and which will also set the `driving` [attribute](#additional-attributes) to `true`. See also `Driving` state in [chart](#states) below.)

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -205,4 +205,4 @@ Date | Version | Notes
 20181130 | [2.3.1](https://github.com/pnbruckner/homeassistant-config/blob/a568b8e84c3ea20386af8ddd618d878095ee35cb/custom_components/device_tracker/life360.py) | Do not add zone for Life360 Places whose name matches `home_place`.
 20190123 | [2.4.0](https://github.com/pnbruckner/homeassistant-config/blob/0f0254c1137255662e1fe53e0d08a8bbf4e2f1b2/custom_components/device_tracker/life360.py) | Add `time_as` option.
 20190129 | [2.5.0](https://github.com/pnbruckner/homeassistant-config/blob/93ed07bb61f40dfdc36e970968726ba16a8510a3/custom_components/device_tracker/life360.py) | Add `waring_threshold` and `error_threshold`.
-201902xx | [2.6.0]() | Add `except_home`, `only_home` and `all` options for `add_zones`, and add `device_tracker.life360_zones_from_places` service. Update life360 package from PyPI to 2.1.0.
+201902xx | [2.6.0]() | Add `only_home`, `except_home` and `all` options for `add_zones`, and add `device_tracker.life360_zones_from_places` service. Update life360 package from PyPI to 2.1.0.

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -197,4 +197,4 @@ Date | Version | Notes
 20181130 | [2.3.1](https://github.com/pnbruckner/homeassistant-config/blob/a568b8e84c3ea20386af8ddd618d878095ee35cb/custom_components/device_tracker/life360.py) | Do not add zone for Life360 Places whose name matches `home_place`.
 20190123 | [2.4.0](https://github.com/pnbruckner/homeassistant-config/blob/0f0254c1137255662e1fe53e0d08a8bbf4e2f1b2/custom_components/device_tracker/life360.py) | Add `time_as` option.
 20190129 | [2.5.0](https://github.com/pnbruckner/homeassistant-config/blob/93ed07bb61f40dfdc36e970968726ba16a8510a3/custom_components/device_tracker/life360.py) | Add `waring_threshold` and `error_threshold`.
-201902xx | [2.6.0]() | Add `include_home` option for `add_zones` and `device_tracker.life360_zones_from_places` service.
+201902xx | [2.6.0]() | Add `include_home` option for `add_zones` and `device_tracker.life360_zones_from_places` service. Update life360 package from PyPI to 2.1.0.

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -78,6 +78,10 @@ wifi_on | Device WiFi is turned on (`true`/`false`.)
 It is not uncommon for communication errors to occur between Home Assistant and the Life360 server. This can happen for many reasons, including Internet connection issues, Life360 server load, etc. However, in most cases, they are temporary and do not significantly affect the ability to keep device_tracker entities up to date.
 
 Therefore an optional filtering mechanism has been implemented to prevent inconsequential communication errors from filling the log, while still logging unusual error activity. Two thresholds are defined: `warning_threshold` and `error_threshold`. When a particular type of communication error happens on consecutive update cycles, it will not be logged until the number of occurences exceeds these thresholds. When the number exceeds `warning_threshold` (but does not exceed `error_threshold`, and only if `warning_threshold` is defined) it will be logged as a WARNING. Once the number exceeds `error_threshold` it will be logged as an ERROR. Only two consecutive communication errors of a particular type will be logged as an ERROR, after which it will no longer be logged until it stops occuring.
+## Services
+Service | Description
+-|-
+`device_tracker.life360_zones_from_places` | Update HA zones from Life360 Places per `add_zones` configuration. Only available if `add_zones` is not `false`.
 ## Examples
 ### Example full configuration
 ```yaml


### PR DESCRIPTION
Add a new choice for the add_zones config variable, specifically include_home_place. If selected, zone.home will be updated to coincide with the Life360 Place whose name matches home_place (case insensitive.) Update to life360 package 2.1.0 (that handles HTTP error 403.) Bump version to 2.6.0b1.