### PR TITLE
Life360: Fail setup only on login errors

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -8,7 +8,7 @@
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/composite.md#release-notes"
   },
   "device_tracker.life360": {
-    "updated_at": "2019-02-xx",
+    "updated_at": "2019-02-19",
     "version": "2.7.0",
     "local_location": "/custom_components/device_tracker/life360.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/life360.py",

--- a/custom_components.json
+++ b/custom_components.json
@@ -8,8 +8,8 @@
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/composite.md#release-notes"
   },
   "device_tracker.life360": {
-    "updated_at": "2019-02-08",
-    "version": "2.6.0",
+    "updated_at": "2019-02-xx",
+    "version": "2.7.0",
     "local_location": "/custom_components/device_tracker/life360.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/life360.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -35,7 +35,7 @@ from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '2.7.0b1'
+__version__ = '2.7.0b2'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -165,11 +165,11 @@ def setup_scanner(hass, config, see, discovery_info=None):
     # Ignore other errors at this time. Hopefully they're temporary.
     except Exception as exc:
         _LOGGER.warning('Ignoring: {}'.format(exc_msg(exc)))
-        pass
     _LOGGER.debug('Setup successful!')
 
     members = config.get(CONF_MEMBERS)
-    _LOGGER.debug('Configured members = {}'.format(members))
+    _LOGGER.debug('Configured members = {}'.format(
+        members if members else 'None specified; will include all'))
 
     if members:
         _members = []

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -35,7 +35,7 @@ from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '2.7.0b2'
+__version__ = '2.7.0'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -206,3 +206,4 @@ Date | Version | Notes
 20190123 | [2.4.0](https://github.com/pnbruckner/homeassistant-config/blob/0f0254c1137255662e1fe53e0d08a8bbf4e2f1b2/custom_components/device_tracker/life360.py) | Add `time_as` option.
 20190129 | [2.5.0](https://github.com/pnbruckner/homeassistant-config/blob/93ed07bb61f40dfdc36e970968726ba16a8510a3/custom_components/device_tracker/life360.py) | Add `waring_threshold` and `error_threshold`.
 20190208 | [2.6.0](https://github.com/pnbruckner/homeassistant-config/blob/16e275ee7b4ffe8616d3c789abf99420e9323309/custom_components/device_tracker/life360.py) | Add `only_home`, `except_home` and `all` options for `add_zones`, and add `device_tracker.life360_zones_from_places` service. Update life360 package from PyPI to 2.1.0.
+201902xx | [2.7.0]() | Treat errors (other than login errors) as warnings during setup and continue. Bump life360 package to 2.2.0.

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -206,4 +206,4 @@ Date | Version | Notes
 20190123 | [2.4.0](https://github.com/pnbruckner/homeassistant-config/blob/0f0254c1137255662e1fe53e0d08a8bbf4e2f1b2/custom_components/device_tracker/life360.py) | Add `time_as` option.
 20190129 | [2.5.0](https://github.com/pnbruckner/homeassistant-config/blob/93ed07bb61f40dfdc36e970968726ba16a8510a3/custom_components/device_tracker/life360.py) | Add `waring_threshold` and `error_threshold`.
 20190208 | [2.6.0](https://github.com/pnbruckner/homeassistant-config/blob/16e275ee7b4ffe8616d3c789abf99420e9323309/custom_components/device_tracker/life360.py) | Add `only_home`, `except_home` and `all` options for `add_zones`, and add `device_tracker.life360_zones_from_places` service. Update life360 package from PyPI to 2.1.0.
-201902xx | [2.7.0]() | Treat errors (other than login errors) as warnings during setup and continue. Bump life360 package to 2.2.0.
+20190219 | [2.7.0]() | Treat errors (other than login errors) as warnings during setup and continue. Bump life360 package to 2.2.0.


### PR DESCRIPTION
Bump life360 package to 2.2.0 which provides unique exception for login errors. Fail setup only on login errors. Log any other errors during setup as warnings and continue. Bump to 2.7.0. Resolves #65.