### PR TITLE
Life360: Delay overdue update events at startup

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -8,8 +8,8 @@
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/composite.md#release-notes"
   },
   "device_tracker.life360": {
-    "updated_at": "2019-02-19",
-    "version": "2.7.0",
+    "updated_at": "2019-02-22",
+    "version": "2.8.0",
     "local_location": "/custom_components/life360/device_tracker.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/life360.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -35,7 +35,7 @@ from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '2.8.0b1'
+__version__ = '2.8.0'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/device_tracker/life360.py
+++ b/custom_components/device_tracker/life360.py
@@ -35,7 +35,7 @@ from homeassistant.util.distance import convert
 import homeassistant.util.dt as dt_util
 
 
-__version__ = '2.7.0'
+__version__ = '2.8.0b1'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,6 +46,7 @@ DEFAULT_FILENAME = 'life360.conf'
 DEFAULT_HOME_PLACE = 'Home'
 SPEED_FACTOR_MPH = 2.25
 MIN_ZONE_INTERVAL = timedelta(minutes=1)
+EVENT_DELAY = timedelta(seconds=30)
 
 DATA_LIFE360 = 'life360'
 
@@ -386,9 +387,10 @@ class Life360Scanner:
             last_seen = None
 
         if self._max_update_wait:
+            now = dt_util.utcnow()
             update = last_seen or prev_seen or self._started
-            overdue = dt_util.utcnow() - update > self._max_update_wait
-            if overdue and not reported:
+            overdue = now - update > self._max_update_wait
+            if overdue and not reported and now - self._started > EVENT_DELAY:
                 self._hass.bus.fire(
                     'life360_update_overdue',
                     {'entity_id': DT_ENTITY_ID_FORMAT.format(dev_id)})

--- a/custom_components_old.json
+++ b/custom_components_old.json
@@ -8,8 +8,8 @@
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/composite.md#release-notes"
   },
   "device_tracker.life360": {
-    "updated_at": "2019-02-19",
-    "version": "2.7.0",
+    "updated_at": "2019-02-22",
+    "version": "2.8.0",
     "local_location": "/custom_components/device_tracker/life360.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/life360.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -211,3 +211,4 @@ Date | Version | Notes
 20190129 | [2.5.0](https://github.com/pnbruckner/homeassistant-config/blob/93ed07bb61f40dfdc36e970968726ba16a8510a3/custom_components/device_tracker/life360.py) | Add `waring_threshold` and `error_threshold`.
 20190208 | [2.6.0](https://github.com/pnbruckner/homeassistant-config/blob/16e275ee7b4ffe8616d3c789abf99420e9323309/custom_components/device_tracker/life360.py) | Add `only_home`, `except_home` and `all` options for `add_zones`, and add `device_tracker.life360_zones_from_places` service. Update life360 package from PyPI to 2.1.0.
 20190219 | [2.7.0](https://github.com/pnbruckner/homeassistant-config/blob/eaadca76efe9721d93dc8cee967b1ff819ddc374/custom_components/device_tracker/life360.py) | Treat errors (other than login errors) as warnings during setup and continue. Bump life360 package to 2.2.0.
+20190222 | [2.8.0]() | Delay firing events at startup so automations have a chance to get ready.


### PR DESCRIPTION
Delay overdue update events at startup to give automations time to get ready. Bump to 2.8.0. Resolves #98.