### PR TITLE
Adapt to new custom_components folder layout

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -2,7 +2,7 @@
   "device_tracker.composite": {
     "updated_at": "2019-01-23",
     "version": "1.7.0",
-    "local_location": "/custom_components/device_tracker/composite.py",
+    "local_location": "/custom_components/composite/device_tracker.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/composite.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/composite.md#release-notes"
@@ -10,7 +10,7 @@
   "device_tracker.life360": {
     "updated_at": "2019-02-19",
     "version": "2.7.0",
-    "local_location": "/custom_components/device_tracker/life360.py",
+    "local_location": "/custom_components/life360/device_tracker.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/life360.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/life360.md#release-notes"
@@ -18,7 +18,7 @@
   "sensor.illuminance": {
     "updated_at": "2019-01-11",
     "version": "2.0.1",
-    "local_location": "/custom_components/sensor/illuminance.py",
+    "local_location": "/custom_components/illuminance/sensor.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/sensor/illuminance.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/illuminance.md#release-notes"

--- a/custom_components_old.json
+++ b/custom_components_old.json
@@ -1,0 +1,34 @@
+{
+  "device_tracker.composite": {
+    "updated_at": "2019-01-23",
+    "version": "1.7.0",
+    "local_location": "/custom_components/device_tracker/composite.py",
+    "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/composite.py",
+    "visit_repo": "https://github.com/pnbruckner/homeassistant-config",
+    "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/composite.md#release-notes"
+  },
+  "device_tracker.life360": {
+    "updated_at": "2019-02-19",
+    "version": "2.7.0",
+    "local_location": "/custom_components/device_tracker/life360.py",
+    "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/device_tracker/life360.py",
+    "visit_repo": "https://github.com/pnbruckner/homeassistant-config",
+    "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/life360.md#release-notes"
+  },
+  "sensor.illuminance": {
+    "updated_at": "2019-01-11",
+    "version": "2.0.1",
+    "local_location": "/custom_components/sensor/illuminance.py",
+    "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/sensor/illuminance.py",
+    "visit_repo": "https://github.com/pnbruckner/homeassistant-config",
+    "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/illuminance.md#release-notes"
+  },
+  "sun": {
+    "updated_at": "2019-02-19",
+    "version": "1.1.0",
+    "local_location": "/custom_components/sun.py",
+    "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/sun.py",
+    "visit_repo": "https://github.com/pnbruckner/homeassistant-config",
+    "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/sun.md#release-notes"
+  }
+}

--- a/docs/composite.md
+++ b/docs/composite.md
@@ -7,11 +7,11 @@ See [Installing and Updating](custom_updater.md) to use Custom Updater. The name
 
 Alternatively, place a copy of:
 
-[device_tracker/composite.py](../custom_components/device_tracker/composite.py) at `<config>/custom_components/device_tracker/composite.py`
+[device_tracker/composite.py](../custom_components/device_tracker/composite.py) at `<config>/custom_components/composite/device_tracker.py`
 
 Or, if using a version of Home Assistant before 0.86, place a copy of:
 
-[device_tracker/composite.py](../custom_components/device_tracker/composite.py) at `<config>/custom_components/composite/device_tracker.py`
+[device_tracker/composite.py](../custom_components/device_tracker/composite.py) at `<config>/custom_components/device_tracker/composite.py`
 
 where `<config>` is your Home Assistant configuration directory.
 

--- a/docs/composite.md
+++ b/docs/composite.md
@@ -9,6 +9,10 @@ Alternatively, place a copy of:
 
 [device_tracker/composite.py](../custom_components/device_tracker/composite.py) at `<config>/custom_components/device_tracker/composite.py`
 
+Or, if using a version of Home Assistant before 0.86, place a copy of:
+
+[device_tracker/composite.py](../custom_components/device_tracker/composite.py) at `<config>/custom_components/composite/device_tracker.py`
+
 where `<config>` is your Home Assistant configuration directory.
 
 >__NOTE__: Do not download the file by using the link above directly. Rather, click on it, then on the page that comes up use the `Raw` button.

--- a/docs/custom_updater.md
+++ b/docs/custom_updater.md
@@ -16,6 +16,12 @@ custom_updater:
   python_script_urls:
     - https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/python_scripts.json
 ```
+#### Home Assistant Versions before 0.86
+Use the following config for `component_urls:` instead:
+```
+  component_urls:
+    - https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components_old.json
+```
 ### Installing
 To install one of these custom components or Python scripts for the first time, use the [`custom_updater.install`](https://github.com/custom-components/custom_updater/wiki/Services#install-element-cardcomponentpython_script) service with appropriate service data, such as:
 ```

--- a/docs/illuminance.md
+++ b/docs/illuminance.md
@@ -16,6 +16,10 @@ See [Installing and Updating](custom_updater.md) to use Custom Updater. The name
 
 Alternatively, place a copy of:
 
+[sensor/illuminance.py](../custom_components/sensor/illuminance.py) at `<config>/custom_components/illuminance/sensor.py`
+
+Or, if using a version of Home Assistant before 0.86, place a copy of:
+
 [sensor/illuminance.py](../custom_components/sensor/illuminance.py) at `<config>/custom_components/sensor/illuminance.py`
 
 where `<config>` is your Home Assistant configuration directory.

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -5,6 +5,10 @@ See [Installing and Updating](custom_updater.md) to use Custom Updater. The name
 
 Alternatively, place a copy of:
 
+[device_tracker/life360.py](../custom_components/device_tracker/life360.py) at `<config>/custom_components/life360/device_tracker.py`
+
+Or, if using a version of Home Assistant before 0.86, place a copy of:
+
 [device_tracker/life360.py](../custom_components/device_tracker/life360.py) at `<config>/custom_components/device_tracker/life360.py`
 
 where `<config>` is your Home Assistant configuration directory.


### PR DESCRIPTION
Starting with 0.86 custom platforms must be in custom_components/<platform_name>/<domain_name>.py instead of custom_components/<domain_name>/<platform_name>.py. Resolves #100.