### PR TITLE
Update main key to make custom_updater work again

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -1,5 +1,5 @@
 {
-  "composite.device_tracker": {
+  "device_tracker.composite": {
     "updated_at": "2019-01-23",
     "version": "1.7.0",
     "local_location": "/custom_components/composite/device_tracker.py",
@@ -7,7 +7,7 @@
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/composite.md#release-notes"
   },
-  "life360.device_tracker": {
+  "device_tracker.life360": {
     "updated_at": "2019-02-22",
     "version": "2.8.0",
     "local_location": "/custom_components/life360/device_tracker.py",
@@ -15,7 +15,7 @@
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/life360.md#release-notes"
   },
-  "illuminance.sensor": {
+  "sensor.illuminance": {
     "updated_at": "2019-01-11",
     "version": "2.0.1",
     "local_location": "/custom_components/illuminance/sensor.py",


### PR DESCRIPTION
Fix for custom_updater. The "name" (main key) of the platform should be in the domain.name format.
https://github.com/custom-components/custom_updater/wiki/components#json-file-examples