### PR TITLE
Illuminance: Adjust to HA 0.89 release (HA PR #21069)

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -16,8 +16,8 @@
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/life360.md#release-notes"
   },
   "sensor.illuminance": {
-    "updated_at": "2019-01-11",
-    "version": "2.0.1",
+    "updated_at": "2019-03-07",
+    "version": "2.0.2",
     "local_location": "/custom_components/illuminance/sensor.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/illuminance/sensor.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/illuminance/sensor.py
+++ b/custom_components/illuminance/sensor.py
@@ -22,8 +22,12 @@ try:
 except ImportError:
     from homeassistant.components.sensor.darksky import (
         CONF_ATTRIBUTION as DSS_ATTRIBUTION)
-from homeassistant.components.sensor.yr import (
-    CONF_ATTRIBUTION as YRS_ATTRIBUTION)
+try:
+    from homeassistant.components.sensor.yr import (
+        ATTRIBUTION as YRS_ATTRIBUTION)
+except ImportError:
+    from homeassistant.components.sensor.yr import (
+        CONF_ATTRIBUTION as YRS_ATTRIBUTION)
 from homeassistant.components.weather.darksky import (
     ATTRIBUTION as DSW_ATTRIBUTION, MAP_CONDITION as DSW_MAP_CONDITION)
 from homeassistant.const import (
@@ -38,7 +42,7 @@ from homeassistant.helpers.event import (
 from homeassistant.helpers.sun import get_astral_event_date
 import homeassistant.util.dt as dt_util
 
-__version__ = '2.0.1'
+__version__ = '2.0.2'
 
 DEFAULT_NAME = 'Illuminance'
 MIN_SCAN_INTERVAL = dt.timedelta(minutes=5)

--- a/custom_components_old.json
+++ b/custom_components_old.json
@@ -16,8 +16,8 @@
     "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/life360.md#release-notes"
   },
   "sensor.illuminance": {
-    "updated_at": "2019-01-11",
-    "version": "2.0.1",
+    "updated_at": "2019-03-07",
+    "version": "2.0.2",
     "local_location": "/custom_components/sensor/illuminance.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/illuminance/sensor.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/docs/illuminance.md
+++ b/docs/illuminance.md
@@ -87,4 +87,5 @@ Date | Version | Notes
 -|:-:|-
 20180907 | [1.0.0](https://github.com/pnbruckner/homeassistant-config/blob/d767bcce0fdff0c9298dc7a010d27af88817eac2/custom_components/sensor/illuminance.py) | Initial support for Custom Updater.
 20181028 | [2.0.0](https://github.com/pnbruckner/homeassistant-config/blob/e4fbbfe5ccc48cc08045226197c5c27767ec081e/custom_components/sensor/illuminance.py) | Add support for using Dark Sky or YR entity as source of weather conditions. For WU, no longer get sunrise/sunset data from the server, just use HA’s sun data.
-20190111 | [2.0.1](https://github.com/pnbruckner/homeassistant-config/blob/be6879c5ff4c4ae67e9b082229a53fc133642d2f/custom_components/sensor/illuminance.py) | Fix bug caused by change in Dark Sky Sensor in HA 0.85 release.
+20190111 | [2.0.1](https://github.com/pnbruckner/homeassistant-config/blob/be6879c5ff4c4ae67e9b082229a53fc133642d2f/custom_components/sensor/illuminance.py) | Adapt to change in Dark Sky Sensor in HA 0.85 release (see [PR #19492](https://github.com/home-assistant/home-assistant/pull/19492).)
+20190307 | [2.0.2]() | Adapt to change in Yr Sensor in HA 0.89 release (see [PR #21069](https://github.com/home-assistant/home-assistant/pull/21069).)


### PR DESCRIPTION
CONF_ATTRIBUTION in homeassistant.components.sensor.yr was renamed to ATTRIBUTION. Bump version to 2.0.2. Resolves #111.