### PR TITLE
Amcrest: Add backwards compatibility with pre-0.86 and custom_updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ### [Installing & Updating Custom Components & Python Scripts](docs/custom_updater.md)
 ## Custom Components
 ### [Amcrest Camera](docs/amcrest.md)
-> __NOTE__: The Amcrest Camera components are not supported via Custom Updater.
+> __NOTE__: The Amcrest Camera components are only supported via Custom Updater with HA versions 0.86 or later.
 ### [Composite Device Tracker platform](docs/composite.md)
 ### [Life360 Device Tracker platform](docs/life360.md)
 ### [Illuminance Sensor](docs/illuminance.md)

--- a/custom_components.json
+++ b/custom_components.json
@@ -1,4 +1,18 @@
 {
+  "amcrest": {
+    "updated_at": "2019-03-08",
+    "version": "1.0.0",
+    "local_location": "/custom_components/amcrest/__init__.py",
+    "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/amcrest/__init__.py",
+    "visit_repo": "https://github.com/pnbruckner/homeassistant-config",
+    "changelog": "https://github.com/pnbruckner/homeassistant-config/blob/master/docs/amcrest.md",
+    "resources": [
+      "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/amcrest/binary_sensor.py",
+      "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/amcrest/camera.py",
+      "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/amcrest/sensor.py",
+      "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/amcrest/switch.py"
+    ]
+  },
   "device_tracker.composite": {
     "updated_at": "2019-01-23",
     "version": "1.7.0",

--- a/custom_components/amcrest/__init__.py
+++ b/custom_components/amcrest/__init__.py
@@ -13,6 +13,9 @@ from homeassistant.const import (
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
+
+__version__ = '1.0.0'
+
 REQUIREMENTS = ['amcrest==1.2.5']
 DEPENDENCIES = ['ffmpeg']
 

--- a/custom_components/amcrest/binary_sensor.py
+++ b/custom_components/amcrest/binary_sensor.py
@@ -2,11 +2,16 @@
 import asyncio
 from datetime import timedelta
 import logging
+
 from requests.exceptions import RequestException
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.const import CONF_NAME, CONF_BINARY_SENSORS
-from . import DATA_AMCREST, BINARY_SENSORS
+try:
+    from . import DATA_AMCREST, BINARY_SENSORS
+except ImportError:
+    from custom_components.amcrest import DATA_AMCREST, BINARY_SENSORS
+
 
 DEPENDENCIES = ['amcrest']
 

--- a/custom_components/amcrest/camera.py
+++ b/custom_components/amcrest/camera.py
@@ -16,8 +16,11 @@ from homeassistant.helpers.aiohttp_client import (
     async_get_clientsession, async_aiohttp_proxy_web,
     async_aiohttp_proxy_stream)
 from homeassistant.helpers.service import extract_entity_ids
-from . import (
-    DATA_AMCREST, STREAM_SOURCE_LIST, TIMEOUT)
+try:
+    from . import (DATA_AMCREST, STREAM_SOURCE_LIST, TIMEOUT)
+except ImportError:
+    from custom_components.amcrest import (
+        DATA_AMCREST, STREAM_SOURCE_LIST, TIMEOUT)
 
 
 DEPENDENCIES = ['amcrest', 'ffmpeg']

--- a/docs/amcrest.md
+++ b/docs/amcrest.md
@@ -1,6 +1,15 @@
 # Amcrest Camera
 [__`amcrest/__init__.py`__](../custom_components/amcrest/__init__.py)  
 [__`amcrest/binary_sensor.py`__](../custom_components/amcrest/binary_sensor.py)  
-[__`amcrest/camera.py`__](../custom_components/amcrest/camera.py)
+[__`amcrest/camera.py`__](../custom_components/amcrest/camera.py)  
+[__`amcrest/sensor.py`__](../custom_components/amcrest/sensor.py)  
+[__`amcrest/switch.py`__](../custom_components/amcrest/switch.py)
+
+>Note: If using HA versions before 0.86, only the first three files are needed, and they go here:
+```
+custom_components/amcrest.py
+custom_components/binary_sensor/amcrest.py
+custom_components/camera/amcrest.py
+```
 
 These custom components are enhanced versions of the standard Amcrest Camera components. They add services and create a new binary sensor for motion detected. They also add thread locking to avoid simultaneous camera commands that lead to constant errors.


### PR DESCRIPTION
Make import statements work with HA releases prior to 0.86. Add `__version__` to be compatible with custom_updater. Resolves #109.