### PR TITLE
Still need REQUIREMENTS & DEPENDENCIES for older HA versions

### DIFF
--- a/custom_components.json
+++ b/custom_components.json
@@ -1,7 +1,7 @@
 {
   "amcrest": {
     "updated_at": "2019-04-19",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "local_location": "/custom_components/amcrest/__init__.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/amcrest/__init__.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components.json
+++ b/custom_components.json
@@ -16,7 +16,7 @@
   },
   "device_tracker.composite": {
     "updated_at": "2019-04-19",
-    "version": "1.7.2",
+    "version": "1.7.3",
     "local_location": "/custom_components/composite/__init__.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/composite/__init__.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",
@@ -28,7 +28,7 @@
   },
   "device_tracker.life360": {
     "updated_at": "2019-04-19",
-    "version": "2.9.2",
+    "version": "2.9.3",
     "local_location": "/custom_components/life360/__init__.py",
     "remote_location": "https://raw.githubusercontent.com/pnbruckner/homeassistant-config/master/custom_components/life360/__init__.py",
     "visit_repo": "https://github.com/pnbruckner/homeassistant-config",

--- a/custom_components/amcrest/__init__.py
+++ b/custom_components/amcrest/__init__.py
@@ -12,7 +12,10 @@ from homeassistant.const import (
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
-__version__ = '1.3.2'
+__version__ = '1.3.3'
+
+REQUIREMENTS = ['amcrest==1.3.0']	
+DEPENDENCIES = ['ffmpeg']	
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/composite/__init__.py
+++ b/custom_components/composite/__init__.py
@@ -1,3 +1,5 @@
 """Composite Device Tracker."""
 
-__version__ = '1.7.2'
+__version__ = '1.7.3'
+
+REQUIREMENTS = ['timezonefinderL==2.0.1']

--- a/custom_components/life360/__init__.py
+++ b/custom_components/life360/__init__.py
@@ -1,3 +1,6 @@
 """Life360 Device Tracker."""
 
-__version__ = '2.9.2'
+__version__ = '2.9.3'
+
+REQUIREMENTS = ['life360==3.0.0', 'timezonefinderL==2.0.1']
+DEPENDENCIES = ['zone']

--- a/docs/composite.md
+++ b/docs/composite.md
@@ -114,3 +114,4 @@ Date | Version | Notes
 20190123 | [1.7.0](https://github.com/pnbruckner/homeassistant-config/blob/0f0254c1137255662e1fe53e0d08a8bbf4e2f1b2/custom_components/device_tracker/composite.py) | Add `time_as` option.
 20190419 | [1.7.1](https://github.com/pnbruckner/homeassistant-config/blob/4f638d1ac9abd12f7bc1e8080763b545fd2385fa/custom_components/composite/device_tracker.py) | Add manifest.json required by 0.92.
 20190419 | [1.7.2](https://github.com/pnbruckner/homeassistant-config/blob/6da2f09b5cf49db3b02403958e41763231c0a7ec/custom_components/composite) | ... and apparently custom_updater needs an `__init__.py` file, too.
+20190419 | [1.7.3]() | ... and older HA versions still need REQUIREMENTS & DEPENDENCIES!

--- a/docs/life360.md
+++ b/docs/life360.md
@@ -217,3 +217,4 @@ Date | Version | Notes
 20190321 | [2.9.0](https://github.com/pnbruckner/homeassistant-config/blob/3c019c1d47d4376fb2787185fd717854983a685b/custom_components/life360/device_tracker.py) | Bump life360 package to 3.0.0 which saves credentials in authorization cache file and checks if the credentials have changed when loading. If they have changed, cache is discarded and a new authorization token is obtained and cached.
 20190419 | [2.9.1](https://github.com/pnbruckner/homeassistant-config/blob/4f638d1ac9abd12f7bc1e8080763b545fd2385fa/custom_components/life360/device_tracker.py) | Add manifest.json required by 0.92.
 20190419 | [2.9.2](https://github.com/pnbruckner/homeassistant-config/blob/6da2f09b5cf49db3b02403958e41763231c0a7ec/custom_components/life360) | ... and apparently custom_updater needs an `__init__.py` file, too.
+20190419 | [2.9.3]() | ... and older HA versions still need REQUIREMENTS & DEPENDENCIES!


### PR DESCRIPTION
D'oh! Sure, 0.92 needs manifest.json, but older versions still need REQUIREMENTS and DEPENDENCIES. So keep them both!