### PR TITLE
light_store.py added support for transition time on restore

### DIFF
--- a/docs/light_store.md
+++ b/docs/light_store.md
@@ -23,6 +23,7 @@ See [Python Scripts](https://www.home-assistant.io/components/python_script/) fo
 - **entity_id** (*Optional*): The entity_id(s) of the entities to save/restore. (Currently only entities of the switch, light or group domains are supported. Groups will be expanded recursively into the individual entities they contain.) Can be a single entity_id, a list of entity_id’s, or a string containing a comma separated list of entity_id’s. When saving, the default is to save all existing switch and light entities. When restoring, the default is to restore all previously saved entities.
 - **operation** (*Optional*): If specified must be `save` or `restore`. The default is `save`.
 - **overwrite** (*Optional*): Only applies to saving. If True will overwrite any previously saved states. If False, will only save current states if they have not already been saved, otherwise will skip saving. The default is True.
+- **transition** (*Optional*): Only applies to restoring. If specified sets the number of seconds the lights will take to transition back to the previous state. The default is `1`.
 ## Operation
 When saving, the script will create an entity in the State Machine named `<store_name>.<domain>_<object_id>` for each saved entity (where `<entity_id>` = `<domain>.<object_id>`.) The state will be the state of the entity, and if the entity is a light then appropriate attributes will also be saved (see below.)
 
@@ -61,6 +62,7 @@ script:
         data:
           store_name: flash_store
           operation: restore
+          transition: 10
 ```
 ## Caveats
 If you have any light groups (i.e., an entity of the light domain that is actually a group of other lights), then you should not use the default for entity_id (when saving.) Rather, you should specify the list of individual light entity_id’s, or the light group, but not both. Unfortunately, a python_script cannot tell the difference between a light entity that is an actual light and a light entity that is a group of other lights. If both are saved & later restored, the result will not be what you want.
@@ -70,3 +72,4 @@ Date | Version | Notes
 20181002 | [1.0.0](https://github.com/pnbruckner/homeassistant-config/blob/62e517921e9f48625dbc7c7e3b9d6b4e665749f4/python_scripts/light_store.py) | Initial support for Custom Updater.
 20190114 | [1.1.0](https://github.com/pnbruckner/homeassistant-config/blob/c405e9ed1f37a67918d5b43152307aa47e75c094/python_scripts/light_store.py) | Save and restore light effect attribute.
 20190204 | [1.2.0](https://github.com/pnbruckner/homeassistant-config/blob/aa04afe8e32777414abb5a9265c00a90efa5d67c/python_scripts/light_store.py) | Add optional `overwrite` parameter.
+20191016 | [1.3.0](https://github.com/pnbruckner/homeassistant-config/blob/aa04afe8e32777414abb5a9265c00a90efa5d67c/python_scripts/light_store.py) | Add optional `transition` parameter.

--- a/python_scripts/light_store.py
+++ b/python_scripts/light_store.py
@@ -1,4 +1,4 @@
-VERSION = '1.2.0'
+VERSION = '1.3.0'
 
 DOMAIN = 'light_store'
 
@@ -6,6 +6,7 @@ ATTR_OPERATION  = 'operation'
 ATTR_OP_SAVE    = 'save'
 ATTR_OP_RESTORE = 'restore'
 ATTR_OVERWRITE  = 'overwrite'
+ATTR_TRANSITION = 'transition'
 
 ATTR_STORE_NAME = 'store_name'
 ATTR_ENTITY_ID  = 'entity_id'
@@ -110,6 +111,9 @@ else:
                 component = entity_id.split('.')[0]
                 if component == 'light' and turn_on and old_state.attributes:
                     service_data.update(old_state.attributes)
+                # Get optional transition parameter (only applies to restoring.)
+                transition = {'transition': data.get(ATTR_TRANSITION, 1)}
+                service_data.update(transition)
                 hass.services.call(component,
                                    'turn_on' if turn_on else 'turn_off',
                                    service_data)


### PR DESCRIPTION
Hi,

I've added support to light_store.py for specifying a transition time for the lights to use when restoring.  Not sure if you wanted to incorporate this into your master copy.

Cheers
Sam