### PR TITLE
Use Kelvin as the preferred color temperature unit

### DIFF
--- a/python_scripts/light_store.py
+++ b/python_scripts/light_store.py
@@ -14,12 +14,12 @@ ATTR_ENTITY_ID  = 'entity_id'
 ATTR_BRIGHTNESS = "brightness"
 ATTR_EFFECT = "effect"
 ATTR_WHITE_VALUE = "white_value"
-ATTR_COLOR_TEMP = "color_temp"
+ATTR_COLOR_TEMP_KLEVIN = "color_temp_kelvin"
 ATTR_HS_COLOR = "hs_color"
 # Save any of these attributes.
 GEN_ATTRS = [ATTR_BRIGHTNESS, ATTR_EFFECT]
 # Save only one of these attributes, in order of precedence.
-COLOR_ATTRS = [ATTR_WHITE_VALUE, ATTR_COLOR_TEMP, ATTR_HS_COLOR]
+COLOR_ATTRS = [ATTR_WHITE_VALUE, ATTR_COLOR_TEMP_KELVIN, ATTR_HS_COLOR]
 
 def store_entity_id(store_name, entity_id):
     return '{}.{}'.format(store_name, entity_id.replace('.', '_'))


### PR DESCRIPTION
Starting with HA 2025.1 `color_temp` argument in `turn_on` service, is deprecated and will break in Home Assistant 2026.1. `color_temp_kelvin` argument should be used instead. See: https://developers.home-assistant.io/blog/2024/12/14/kelvin-preferred-color-temperature-unit/

Use Kelvin as the preferred color temperature unit was already introduced in 2022 with https://github.com/home-assistant/core/pull/79591 

This is a breaking change. Please consider to add a deprecation warning and a fallback option to: https://github.com/pnbruckner/homeassistant-config/edit/master/python_scripts/light_store.py before merging into master.